### PR TITLE
HouseKeeping: Moved errors to one place

### DIFF
--- a/.changeset/orange-eyes-march.md
+++ b/.changeset/orange-eyes-march.md
@@ -3,4 +3,4 @@
 "@changesets/config": patch
 ---
 
-Usage Error classes from the @changesets/errors package
+Updated to use the Error classes from the @changesets/errors package

--- a/.changeset/orange-eyes-march.md
+++ b/.changeset/orange-eyes-march.md
@@ -1,0 +1,6 @@
+---
+"@changesets/cli": patch
+"@changesets/config": patch
+---
+
+Usage Error classes from the @changesets/errors package

--- a/.changeset/rare-needles-design.md
+++ b/.changeset/rare-needles-design.md
@@ -1,0 +1,5 @@
+---
+"@changesets/errors": patch
+---
+
+Added ExitError class and ValidationError class

--- a/.changeset/rare-needles-design.md
+++ b/.changeset/rare-needles-design.md
@@ -2,4 +2,5 @@
 "@changesets/errors": patch
 ---
 
-Added ExitError class and ValidationError class
+- Added ExitError class and ValidationError class
+- Extend extendable-error in our error classes instead of JS Error class due to better Error messages thrown 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "yarn.lock" }}
+            - v2-dependencies-{{ checksum "yarn.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v2-dependencies-
       - run:
           name: Install
           command: yarn install --pure-lockfile
@@ -43,9 +43,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "yarn.lock" }}
+            - v2-dependencies-{{ checksum "yarn.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v2-dependencies-
       - run:
           name: Install
           command: yarn install --pure-lockfile
@@ -61,9 +61,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "yarn.lock" }}
+            - v2-dependencies-{{ checksum "yarn.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v2-dependencies-
       - run:
           name: Install
           command: yarn install --pure-lockfile

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
     "@changesets/apply-release-plan": "^0.2.2",
     "@changesets/assemble-release-plan": "^0.2.1",
     "@changesets/config": "^0.2.1",
+    "@changesets/errors": "^0.1.0",
     "@changesets/get-release-plan": "^0.1.3",
     "@changesets/git": "^0.2.3",
     "@changesets/logger": "^0.0.0",

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -1,7 +1,7 @@
 import publishPackages from "./publishPackages";
+import { ExitError } from "@changesets/errors";
 import { error, log, success } from "@changesets/logger";
 import * as git from "@changesets/git";
-import { ExitError } from "../../utils/errors";
 import { Config } from "@changesets/types";
 
 function logReleases(pkgs: Array<{ name: string; newVersion: string }>) {

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -1,3 +1,4 @@
+import { ExitError } from "@changesets/errors";
 import { error, info, warn } from "@changesets/logger";
 import pLimit from "p-limit";
 import chalk from "chalk";
@@ -5,7 +6,6 @@ import spawn from "spawndamnit";
 import { askQuestion } from "../../utils/cli";
 // @ts-ignore
 import isCI from "is-ci";
-import { ExitError } from "../../utils/errors";
 import { TwoFactorState } from "../../utils/types";
 
 const npmRequestLimit = pLimit(40);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 import meow from "meow";
 import { read } from "@changesets/config";
+import { ExitError } from "@changesets/errors";
 import { error } from "@changesets/logger";
 import { Config } from "@changesets/types";
 import fs from "fs-extra";
@@ -11,7 +12,6 @@ import add from "./commands/add";
 import version from "./commands/version";
 import publish from "./commands/publish";
 import status from "./commands/status";
-import { ExitError } from "./utils/errors";
 import { CliOptions } from "./types";
 
 const { input, flags } = meow(

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -1,7 +1,0 @@
-export class ExitError extends Error {
-  code: number;
-  constructor(code: number) {
-    super("the process exited with code: " + code);
-    this.code = code;
-  }
-}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -11,6 +11,7 @@
     "schema.json"
   ],
   "dependencies": {
+    "@changesets/errors": "^0.1.0",
     "@changesets/types": "^0.3.0",
     "fs-extra": "^7.0.1"
   },

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -121,7 +121,7 @@ describe("parser errors", () => {
     expect(() => {
       unsafeParse({ changelog: {} });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Validation Error: Some errors occurred when validating the changesets config:
+"Some errors occurred when validating the changesets config:
 The \`changelog\` option is set as {} when the only valid values are undefined, a module path(e.g. \\"@changesets/cli/changelog\\" or \\"./some-module\\") or a tuple with a module path and config for the changelog generator(e.g. [\\"@changesets/cli/changelog\\", { someOption: true }])"
 `);
   });
@@ -129,7 +129,7 @@ The \`changelog\` option is set as {} when the only valid values are undefined, 
     expect(() => {
       unsafeParse({ changelog: ["some-module", "something", "other"] });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Validation Error: Some errors occurred when validating the changesets config:
+"Some errors occurred when validating the changesets config:
 The \`changelog\` option is set as [
   \\"some-module\\",
   \\"something\\",
@@ -141,7 +141,7 @@ The \`changelog\` option is set as [
     expect(() => {
       unsafeParse({ changelog: [false, "something"] });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Validation Error: Some errors occurred when validating the changesets config:
+"Some errors occurred when validating the changesets config:
 The \`changelog\` option is set as [
   false,
   \\"something\\"
@@ -152,7 +152,7 @@ The \`changelog\` option is set as [
     expect(() => {
       unsafeParse({ access: "something" });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Validation Error: Some errors occurred when validating the changesets config:
+"Some errors occurred when validating the changesets config:
 The \`access\` option is set as \\"something\\" when the only valid values are undefined, \\"public\\" or \\"private\\""
 `);
   });
@@ -160,7 +160,7 @@ The \`access\` option is set as \\"something\\" when the only valid values are u
     expect(() => {
       unsafeParse({ commit: "something" });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Validation Error: Some errors occurred when validating the changesets config:
+"Some errors occurred when validating the changesets config:
 The \`commit\` option is set as \\"something\\" when the only valid values are undefined or a boolean"
 `);
   });
@@ -168,7 +168,7 @@ The \`commit\` option is set as \\"something\\" when the only valid values are u
     expect(() => {
       unsafeParse({ linked: {} });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Validation Error: Some errors occurred when validating the changesets config:
+"Some errors occurred when validating the changesets config:
 The \`linked\` option is set as {} when the only valid values are undefined or an array of arrays of package names"
 `);
   });
@@ -176,7 +176,7 @@ The \`linked\` option is set as {} when the only valid values are undefined or a
     expect(() => {
       unsafeParse({ linked: [{}] });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Validation Error: Some errors occurred when validating the changesets config:
+"Some errors occurred when validating the changesets config:
 The \`linked\` option is set as [
   {}
 ] when the only valid values are undefined or an array of arrays of package names"
@@ -186,7 +186,7 @@ The \`linked\` option is set as [
     expect(() => {
       unsafeParse({ linked: [[{}]] });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Validation Error: Some errors occurred when validating the changesets config:
+"Some errors occurred when validating the changesets config:
 The \`linked\` option is set as [
   [
     {}
@@ -198,7 +198,7 @@ The \`linked\` option is set as [
     expect(() => {
       parse({ linked: [["pkg-a"]] }, []);
     }).toThrowErrorMatchingInlineSnapshot(`
-"Validation Error: Some errors occurred when validating the changesets config:
+"Some errors occurred when validating the changesets config:
 The package \\"pkg-a\\" is specified in the \`linked\` option but it is not found in the project. You may have misspelled the package name."
 `);
   });
@@ -208,7 +208,7 @@ The package \\"pkg-a\\" is specified in the \`linked\` option but it is not foun
         { config: { name: "pkg-a", version: "" }, name: "pkg-a", dir: "dir" }
       ]);
     }).toThrowErrorMatchingInlineSnapshot(`
-"Validation Error: Some errors occurred when validating the changesets config:
+"Some errors occurred when validating the changesets config:
 The package \\"pkg-a\\" is in multiple sets of linked packages. Packages can only be in a single set of linked packages."
 `);
   });

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -121,7 +121,7 @@ describe("parser errors", () => {
     expect(() => {
       unsafeParse({ changelog: {} });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Some errors occurred when validating the changesets config:
+"Validation Error: Some errors occurred when validating the changesets config:
 The \`changelog\` option is set as {} when the only valid values are undefined, a module path(e.g. \\"@changesets/cli/changelog\\" or \\"./some-module\\") or a tuple with a module path and config for the changelog generator(e.g. [\\"@changesets/cli/changelog\\", { someOption: true }])"
 `);
   });
@@ -129,7 +129,7 @@ The \`changelog\` option is set as {} when the only valid values are undefined, 
     expect(() => {
       unsafeParse({ changelog: ["some-module", "something", "other"] });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Some errors occurred when validating the changesets config:
+"Validation Error: Some errors occurred when validating the changesets config:
 The \`changelog\` option is set as [
   \\"some-module\\",
   \\"something\\",
@@ -141,7 +141,7 @@ The \`changelog\` option is set as [
     expect(() => {
       unsafeParse({ changelog: [false, "something"] });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Some errors occurred when validating the changesets config:
+"Validation Error: Some errors occurred when validating the changesets config:
 The \`changelog\` option is set as [
   false,
   \\"something\\"
@@ -152,7 +152,7 @@ The \`changelog\` option is set as [
     expect(() => {
       unsafeParse({ access: "something" });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Some errors occurred when validating the changesets config:
+"Validation Error: Some errors occurred when validating the changesets config:
 The \`access\` option is set as \\"something\\" when the only valid values are undefined, \\"public\\" or \\"private\\""
 `);
   });
@@ -160,7 +160,7 @@ The \`access\` option is set as \\"something\\" when the only valid values are u
     expect(() => {
       unsafeParse({ commit: "something" });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Some errors occurred when validating the changesets config:
+"Validation Error: Some errors occurred when validating the changesets config:
 The \`commit\` option is set as \\"something\\" when the only valid values are undefined or a boolean"
 `);
   });
@@ -168,7 +168,7 @@ The \`commit\` option is set as \\"something\\" when the only valid values are u
     expect(() => {
       unsafeParse({ linked: {} });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Some errors occurred when validating the changesets config:
+"Validation Error: Some errors occurred when validating the changesets config:
 The \`linked\` option is set as {} when the only valid values are undefined or an array of arrays of package names"
 `);
   });
@@ -176,7 +176,7 @@ The \`linked\` option is set as {} when the only valid values are undefined or a
     expect(() => {
       unsafeParse({ linked: [{}] });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Some errors occurred when validating the changesets config:
+"Validation Error: Some errors occurred when validating the changesets config:
 The \`linked\` option is set as [
   {}
 ] when the only valid values are undefined or an array of arrays of package names"
@@ -186,7 +186,7 @@ The \`linked\` option is set as [
     expect(() => {
       unsafeParse({ linked: [[{}]] });
     }).toThrowErrorMatchingInlineSnapshot(`
-"Some errors occurred when validating the changesets config:
+"Validation Error: Some errors occurred when validating the changesets config:
 The \`linked\` option is set as [
   [
     {}
@@ -198,7 +198,7 @@ The \`linked\` option is set as [
     expect(() => {
       parse({ linked: [["pkg-a"]] }, []);
     }).toThrowErrorMatchingInlineSnapshot(`
-"Some errors occurred when validating the changesets config:
+"Validation Error: Some errors occurred when validating the changesets config:
 The package \\"pkg-a\\" is specified in the \`linked\` option but it is not found in the project. You may have misspelled the package name."
 `);
   });
@@ -208,7 +208,7 @@ The package \\"pkg-a\\" is specified in the \`linked\` option but it is not foun
         { config: { name: "pkg-a", version: "" }, name: "pkg-a", dir: "dir" }
       ]);
     }).toThrowErrorMatchingInlineSnapshot(`
-"Some errors occurred when validating the changesets config:
+"Validation Error: Some errors occurred when validating the changesets config:
 The package \\"pkg-a\\" is in multiple sets of linked packages. Packages can only be in a single set of linked packages."
 `);
   });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs-extra";
 import path from "path";
+import { ValidationError } from "@changesets/errors";
 import { Config, WrittenConfig, Workspace } from "@changesets/types";
 import packageJson from "../package.json";
 
@@ -122,7 +123,10 @@ export let parse = (
     }
   }
   if (messages.length) {
-    throw new ValidationError(messages);
+    throw new ValidationError(
+      `Some errors occurred when validating the changesets config:\n` +
+        messages.join("\n")
+    );
   }
 
   let config: Config = {
@@ -142,12 +146,3 @@ export let parse = (
 };
 
 export let defaultConfig = parse(defaultWrittenConfig, []);
-
-export class ValidationError extends Error {
-  constructor(messages: Array<string>) {
-    super(
-      `Some errors occurred when validating the changesets config:\n` +
-        messages.join("\n")
-    );
-  }
-}

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -5,5 +5,8 @@
   "main": "dist/errors.cjs.js",
   "module": "dist/errors.esm.js",
   "license": "MIT",
-  "repository": "https://github.com/changesets/changesets/tree/master/packages/errors"
+  "repository": "https://github.com/changesets/changesets/tree/master/packages/errors",
+  "dependencies": {
+    "extendable-error": "^0.1.5"
+  }
 }

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -1,15 +1,19 @@
 import ExtendableError from "extendable-error";
 
 export class GitError extends ExtendableError {
-  constructor(public code: number, message: string) {
+  code: number;
+  constructor(code: number, message: string) {
     super(`${message}, exit code: ${code}`);
+    this.code = code;
   }
 }
 
 export class ValidationError extends ExtendableError {}
 
 export class ExitError extends ExtendableError {
-  constructor(public code: number) {
+  code: number;
+  constructor(code: number) {
     super(`The process exited with code: ${code}`);
+    this.code = code;
   }
 }

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -3,3 +3,15 @@ export class GitError extends Error {
     super(`Error: Git - ${message}, exit code: ${exitCode}`);
   }
 }
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(`Validation Error: ${message}`);
+  }
+}
+
+export class ExitError extends Error {
+  constructor(public code: number) {
+    super(`ExitError: The process exited with code: ${code}`);
+  }
+}

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -1,17 +1,15 @@
-export class GitError extends Error {
-  constructor(exitCode: number, message: string) {
-    super(`Error: Git - ${message}, exit code: ${exitCode}`);
+import ExtendableError from "extendable-error";
+
+export class GitError extends ExtendableError {
+  constructor(public code: number, message: string) {
+    super(`${message}, exit code: ${code}`);
   }
 }
 
-export class ValidationError extends Error {
-  constructor(message: string) {
-    super(`Validation Error: ${message}`);
-  }
-}
+export class ValidationError extends ExtendableError {}
 
-export class ExitError extends Error {
+export class ExitError extends ExtendableError {
   constructor(public code: number) {
-    super(`ExitError: The process exited with code: ${code}`);
+    super(`The process exited with code: ${code}`);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,6 +2201,11 @@ extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
+extendable-error@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/extendable-error/-/extendable-error-0.1.5.tgz#122308a7097bc89a263b2c4fbf089c78140e3b6d"
+  integrity sha1-EiMIpwl7yJomOyxPvwiceBQOO20=
+
 external-editor@^2.0.4, external-editor@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"


### PR DESCRIPTION
Moved `ExitError` and `ValidationError` out from cli and config package respectively and updated the usage.