### PR TITLE
Skip OTP check during isCI

### DIFF
--- a/.changeset/fluffy-melons-kiss.md
+++ b/.changeset/fluffy-melons-kiss.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Skip OTP check during isCI

--- a/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
@@ -1,0 +1,39 @@
+import { copyFixtureIntoTempDir } from "jest-fixtures";
+
+import publishPackages from "../publishPackages";
+import * as npmUtils from "../npm-utils";
+
+jest.mock("../npm-utils");
+jest.mock("is-ci", () => true);
+
+describe("publishPackages", () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = await copyFixtureIntoTempDir(__dirname, "simple-project");
+
+    // @ts-ignore
+    npmUtils.infoAllow404.mockImplementation(() => ({
+      published: false,
+      pkgInfo: {
+        version: "1.0.0"
+      }
+    }));
+
+    // @ts-ignore
+    npmUtils.publish.mockImplementation(() => ({
+      published: true
+    }));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when isCI", () => {
+    it("does not call out to npm to see if otp is required", async () => {
+      await publishPackages({ cwd, access: "public", preState: undefined });
+      expect(npmUtils.getTokenIsRequired).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -7,6 +7,8 @@ import * as npmUtils from "./npm-utils";
 import { info, warn } from "@changesets/logger";
 import { TwoFactorState } from "../../utils/types";
 import { PreState } from "@changesets/types";
+// @ts-ignore
+import isCI from "is-ci";
 
 export default async function publishPackages({
   cwd,
@@ -26,8 +28,10 @@ export default async function publishPackages({
     otp === undefined
       ? {
           token: null,
-          // note: we're not awaiting this here, we want this request to happen in parallel with getUnpublishedPackages
-          isRequired: npmUtils.getTokenIsRequired()
+          isRequired: isCI
+            ? Promise.resolve(false)
+            : // note: we're not awaiting this here, we want this request to happen in parallel with getUnpublishedPackages
+              npmUtils.getTokenIsRequired()
         }
       : {
           token: otp,


### PR DESCRIPTION
During CI, a token shouldn't be required.