### PR TITLE
Fix the author of a PR not being queried in get-github-info

### DIFF
--- a/.changeset/sixty-turkeys-cover.md
+++ b/.changeset/sixty-turkeys-cover.md
@@ -1,0 +1,6 @@
+---
+"@changesets/get-github-info": patch
+"@changesets/changelog-github": patch
+---
+
+Fix the author of a PR not being queried

--- a/packages/get-github-info/src/index.test.ts
+++ b/packages/get-github-info/src/index.test.ts
@@ -21,6 +21,12 @@ test("associated with multiple PRs with only one merged", async () => {
                     number
                     url
                     mergedAt
+                    author {
+                      user {
+                        login
+                        url
+                      }
+                    }
                   }
                 }
                 author {
@@ -124,6 +130,12 @@ test("associated with multiple PRs with multiple merged gets the one that was me
                     number
                     url
                     mergedAt
+                    author {
+                      user {
+                        login
+                        url
+                      }
+                    }
                   }
                 }
                 author {
@@ -227,6 +239,12 @@ test("gets the author of the associated pull request if it exists rather than th
                     number
                     url
                     mergedAt
+                    author {
+                      user {
+                        login
+                        url
+                      }
+                    }
                   }
                 }
                 author {

--- a/packages/get-github-info/src/index.ts
+++ b/packages/get-github-info/src/index.ts
@@ -26,6 +26,12 @@ function makeQuery(repos: any) {
                 number
                 url
                 mergedAt
+                author {
+                  user {
+                    login
+                    url
+                  }
+                }
               }
             }
             author {


### PR DESCRIPTION
...And this is why I don't like mocking things but anyway, somehow I didn't query for the PR author in #224 but I had responses in the tests that included it ¯\\\_(ツ)_/¯
