### PR TITLE
Fix how multiline changesets of the same type are concatenated

### DIFF
--- a/.changeset/old-pillows-sparkle.md
+++ b/.changeset/old-pillows-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@changesets/apply-release-plan": patch
+---
+
+Ensure there is a newline between release lines so the final markdown preserves correct formatting.

--- a/.changeset/orange-ads-care.md
+++ b/.changeset/orange-ads-care.md
@@ -1,0 +1,6 @@
+---
+"@changesets/changelog-git": patch
+"@changesets/cli": patch
+---
+
+Avoid trailing newline for single-line changesets to avoid double newline between release lines when generating final markdown for changelog.

--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -20,7 +20,7 @@ async function generateChangesForVersionTypeMarkdown(
   let releaseLines = await Promise.all(obj[type]);
   releaseLines = releaseLines.filter(x => x);
   if (releaseLines.length) {
-    return `### ${startCase(type)} Changes\n\n${releaseLines.join("")}`;
+    return `### ${startCase(type)} Changes\n\n${releaseLines.join("\n")}\n`;
   }
 }
 

--- a/packages/changelog-git/src/index.ts
+++ b/packages/changelog-git/src/index.ts
@@ -15,7 +15,11 @@ const getReleaseLine = async (
 
   let returnVal = `- ${
     changeset.commit ? `${changeset.commit}: ` : ""
-  }${firstLine}\n${futureLines.map(l => `  ${l}`).join("\n")}`;
+  }${firstLine}`;
+
+  if (futureLines.length > 0) {
+    returnVal += `\n${futureLines.map(l => `  ${l}`).join("\n")}`;
+  }
 
   return returnVal;
 };

--- a/packages/cli/src/changelog/index.ts
+++ b/packages/cli/src/changelog/index.ts
@@ -16,7 +16,11 @@ const getReleaseLine = async (
 
   let returnVal = `- ${
     changeset.commit ? `${changeset.commit}: ` : ""
-  }${firstLine}\n${futureLines.map(l => `  ${l}`).join("\n")}`;
+  }${firstLine}`;
+
+  if (futureLines.length > 0) {
+    returnVal += `\n${futureLines.map(l => `  ${l}`).join("\n")}`;
+  }
 
   return returnVal;
 };

--- a/packages/get-github-info/README.md
+++ b/packages/get-github-info/README.md
@@ -37,9 +37,13 @@ const getReleaseLine = async (changeset, type) => {
     repo: "Noviny/changesets",
     commit: changeset.commit
   });
-  return `- ${links.commit}${links.pull === null ? "" : ` ${links.pull}`}${
-    links.user === null ? "" : ` Thanks ${links.user}!`
-  }: ${firstLine}\n${futureLines.map(l => `  ${l}`).join("\n")}`;
+  let returnVal = `- ${links.commit}${
+    links.pull === null ? "" : ` ${links.pull}`
+  }${links.user === null ? "" : ` Thanks ${links.user}!`}: ${firstLine}`;
+  if (futureLines.length > 0) {
+    returnVal += `\n${futureLines.map(l => `  ${l}`).join("\n")}`;
+  }
+  return returnVal;
 };
 
 // ...


### PR DESCRIPTION
I'd like to get a preliminary review of the approach I have used here. I will add a test case & changeset sometime later.

**Problem**

Multiline changesets were trimmed and `\n` was not inserted after them, so a next changeset that got appended to the result was appended at the end of the last line which messed up markdown listing etc.