### PR TITLE
Added GitHub Actions support to CI detection

### DIFF
--- a/.changeset/loud-cameras-film.md
+++ b/.changeset/loud-cameras-film.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Added GitHub Actions support to CI detection.

--- a/packages/cli/src/commands/publish/npm-utils.ts
+++ b/packages/cli/src/commands/publish/npm-utils.ts
@@ -6,8 +6,7 @@ import pLimit from "p-limit";
 import chalk from "chalk";
 import spawn from "spawndamnit";
 import { askQuestion } from "../../utils/cli-utilities";
-// @ts-ignore
-import isCI from "is-ci";
+import isCI from "../../utils/isCI";
 import { TwoFactorState } from "../../utils/types";
 
 const npmRequestLimit = pLimit(40);

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -7,8 +7,7 @@ import * as npmUtils from "./npm-utils";
 import { info, warn } from "@changesets/logger";
 import { TwoFactorState } from "../../utils/types";
 import { PreState } from "@changesets/types";
-// @ts-ignore
-import isCI from "is-ci";
+import isCI from "../../utils/isCI";
 
 export default async function publishPackages({
   cwd,

--- a/packages/cli/src/utils/isCI.ts
+++ b/packages/cli/src/utils/isCI.ts
@@ -1,0 +1,4 @@
+// @ts-ignore
+import isCI from "is-ci";
+
+export default !!(isCI || process.env.GITHUB_ACTIONS);


### PR DESCRIPTION
`is-ci` package doesnt detect actions as CI. There is open PR to add support for them ( https://github.com/watson/ci-info/pull/42 ), but unfortunately, it has not been merged for some time already.