### PR TITLE
Fix a bug with prereleases where a package would not be bumped with the highest bump type of all changesets from previous prereleases within the same prerelease run

### DIFF
--- a/.changeset/dirty-coins-enjoy.md
+++ b/.changeset/dirty-coins-enjoy.md
@@ -1,0 +1,6 @@
+---
+"@changesets/assemble-release-plan": patch
+"@changesets/cli": patch
+---
+
+Fix a bug with prereleases where a package would not be bumped with the highest bump type of all changesets from previous prereleases within the same prerelease run

--- a/.changeset/dirty-coins-enjoy.md
+++ b/.changeset/dirty-coins-enjoy.md
@@ -3,4 +3,4 @@
 "@changesets/cli": patch
 ---
 
-Fix a bug with prereleases where a package would not be bumped with the highest bump type of all changesets from previous prereleases within the same prerelease run
+Fixed a bug where only the unreleased pre-release changesets were taken into account when calculating the new version, not previously released changesets.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Jest Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "${workspaceRoot}/node_modules/.bin/jest",
+        "--runInBand"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229
+    }
+  ]
+}

--- a/packages/assemble-release-plan/src/apply-links.ts
+++ b/packages/assemble-release-plan/src/apply-links.ts
@@ -16,7 +16,7 @@ import { InternalRelease } from "./types";
 */
 function applyLinks(
   releases: Map<string, InternalRelease>,
-  workspaces: Workspace[],
+  workspacesByName: Map<string, Workspace>,
   linked: Linked
 ): boolean {
   let updated = false;
@@ -49,9 +49,7 @@ function applyLinks(
 
     // Next we determine what the highest version among the linked packages will be
     for (let linkedPackage of linkedPackages) {
-      let workspace = workspaces.find(
-        workspace => workspace.name === linkedPackage
-      );
+      let workspace = workspacesByName.get(linkedPackage);
 
       if (workspace) {
         if (

--- a/packages/assemble-release-plan/src/flatten-releases.ts
+++ b/packages/assemble-release-plan/src/flatten-releases.ts
@@ -6,14 +6,14 @@ import { InternalRelease } from "./types";
 
 export default function flattenReleases(
   changesets: NewChangeset[],
-  workspaces: Workspace[]
+  workspacesByName: Map<string, Workspace>
 ): Map<string, InternalRelease> {
   let releases: Map<string, InternalRelease> = new Map();
 
   changesets.forEach(changeset => {
     changeset.releases.forEach(({ name, type }) => {
       let release = releases.get(name);
-      let ws = workspaces.find(ws => ws.name === name);
+      let ws = workspacesByName.get(name);
       if (!ws) {
         throw new Error(`Could not find package information for ${name}`);
       }

--- a/packages/assemble-release-plan/src/increment.ts
+++ b/packages/assemble-release-plan/src/increment.ts
@@ -6,13 +6,13 @@ export function incrementVersion(
   release: InternalRelease,
   preInfo: PreInfo | undefined
 ) {
+  console.log(release);
   let version = semver.inc(release.oldVersion, release.type)!;
   if (preInfo !== undefined && preInfo.state.mode !== "exit") {
     let preVersion = preInfo.preVersions.get(release.name);
     if (preVersion === undefined) {
-      console.log(preInfo.preVersions.entries());
       throw new InternalError(
-        `preVersion for ${release.name} does not exis when preState is defined`
+        `preVersion for ${release.name} does not exist when preState is defined`
       );
     }
     // why are we adding this ourselves rather than passing 'pre' + versionType to semver.inc?

--- a/packages/assemble-release-plan/src/increment.ts
+++ b/packages/assemble-release-plan/src/increment.ts
@@ -6,7 +6,6 @@ export function incrementVersion(
   release: InternalRelease,
   preInfo: PreInfo | undefined
 ) {
-  console.log(release);
   let version = semver.inc(release.oldVersion, release.type)!;
   if (preInfo !== undefined && preInfo.state.mode !== "exit") {
     let preVersion = preInfo.preVersions.get(release.name);

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -43,6 +43,8 @@ function assembleReleasePlan(
 
   let workspacesByName = new Map(workspaces.map(x => [x.name, x]));
 
+  let unfilteredChangesets = changesets;
+
   if (updatedPreState !== undefined) {
     for (let workspace of workspaces) {
       if (updatedPreState.initialVersions[workspace.name] === undefined) {
@@ -62,6 +64,36 @@ function assembleReleasePlan(
   // flattened down to one release per package, having a reference back to their
   // changesets, and with a calculated new versions
   let releases = flattenReleases(changesets, workspaces);
+
+  // for every release in pre mode, we want versions to be bumped to the highest bump type
+  // across all the changesets even if the package doesn't have a changeset that releases
+  // to the highest bump type in a given release in pre mode and importantly
+  // we don't want to add any new releases, we only want to update ones that will already happen
+  // because if they're not being released, the version will already have been bumped with the highest bump type
+  if (updatedPreState !== undefined && updatedPreState.mode !== "exit") {
+    let releasesFromUnfilteredChangesets = flattenReleases(
+      unfilteredChangesets,
+      workspaces
+    );
+
+    releases.forEach((value, key) => {
+      let releaseFromUnfilteredChangesets = releasesFromUnfilteredChangesets.get(
+        key
+      );
+      if (releaseFromUnfilteredChangesets === undefined) {
+        throw new InternalError("releaseFromUnfilteredChangesets is undefined");
+      }
+      releases.set(key, {
+        ...value,
+        // note that we're only setting the type, not the changesets which could be different(the name and oldVersion would be the same so they don't matter)
+        // because the changesets on a given release refer to why a given package is being released
+        // NOT why it's being released with a given bump type
+        // (the bump type could change because of this, linked or peer dependencies)
+        type: releaseFromUnfilteredChangesets.type
+      });
+    });
+  }
+
   let preVersions = new Map();
   if (updatedPreState !== undefined) {
     for (let [name, release] of releases) {

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -45,6 +45,7 @@ function assembleReleasePlan(
 
   let unfilteredChangesets = changesets;
 
+  let preVersions = new Map();
   if (updatedPreState !== undefined) {
     for (let workspace of workspaces) {
       if (updatedPreState.initialVersions[workspace.name] === undefined) {
@@ -58,51 +59,6 @@ function assembleReleasePlan(
       changesets = changesets.filter(
         changeset => !usedChangesetIds.has(changeset.id)
       );
-    }
-  }
-  // releases is, at this point a list of all packages we are going to releases,
-  // flattened down to one release per package, having a reference back to their
-  // changesets, and with a calculated new versions
-  let releases = flattenReleases(changesets, workspaces);
-
-  // for every release in pre mode, we want versions to be bumped to the highest bump type
-  // across all the changesets even if the package doesn't have a changeset that releases
-  // to the highest bump type in a given release in pre mode and importantly
-  // we don't want to add any new releases, we only want to update ones that will already happen
-  // because if they're not being released, the version will already have been bumped with the highest bump type
-  if (updatedPreState !== undefined && updatedPreState.mode !== "exit") {
-    let releasesFromUnfilteredChangesets = flattenReleases(
-      unfilteredChangesets,
-      workspaces
-    );
-
-    releases.forEach((value, key) => {
-      let releaseFromUnfilteredChangesets = releasesFromUnfilteredChangesets.get(
-        key
-      );
-      if (releaseFromUnfilteredChangesets === undefined) {
-        throw new InternalError("releaseFromUnfilteredChangesets is undefined");
-      }
-      releases.set(key, {
-        ...value,
-        // note that we're only setting the type, not the changesets which could be different(the name and oldVersion would be the same so they don't matter)
-        // because the changesets on a given release refer to why a given package is being released
-        // NOT why it's being released with a given bump type
-        // (the bump type could change because of this, linked or peer dependencies)
-        type: releaseFromUnfilteredChangesets.type
-      });
-    });
-  }
-
-  let preVersions = new Map();
-  if (updatedPreState !== undefined) {
-    for (let [name, release] of releases) {
-      releases.set(name, {
-        ...release,
-        oldVersion: updatedPreState.initialVersions[name]
-      });
-    }
-    if (updatedPreState.mode !== "exit") {
       for (let workspace of workspaces) {
         preVersions.set(
           workspace.name,
@@ -122,20 +78,66 @@ function assembleReleasePlan(
         }
       }
     }
+    for (let workspace of workspaces) {
+      workspacesByName.set(workspace.name, {
+        ...workspace,
+        config: {
+          ...workspace.config,
+          version: updatedPreState.initialVersions[workspace.name]
+        }
+      });
+    }
   }
 
-  if (updatedPreState !== undefined && updatedPreState.mode === "exit") {
-    for (let workspace of workspaces) {
-      if (semver.parse(workspace.config.version)!.prerelease.length) {
-        if (!releases.has(workspace.name)) {
-          releases.set(workspace.name, {
-            type: "patch",
-            name: workspace.name,
-            changesets: [],
-            oldVersion: updatedPreState.initialVersions[workspace.name]
-          });
+  // releases is, at this point a list of all packages we are going to releases,
+  // flattened down to one release per package, having a reference back to their
+  // changesets, and with a calculated new versions
+  let releases = flattenReleases(changesets, workspacesByName);
+
+  if (updatedPreState !== undefined) {
+    if (updatedPreState.mode === "exit") {
+      for (let workspace of workspaces) {
+        if (preVersions.get(workspace.name) !== -1) {
+          if (!releases.has(workspace.name)) {
+            releases.set(workspace.name, {
+              type: "patch",
+              name: workspace.name,
+              changesets: [],
+              oldVersion: workspace.config.version
+            });
+          }
         }
       }
+    } else {
+      // for every release in pre mode, we want versions to be bumped to the highest bump type
+      // across all the changesets even if the package doesn't have a changeset that releases
+      // to the highest bump type in a given release in pre mode and importantly
+      // we don't want to add any new releases, we only want to update ones that will already happen
+      // because if they're not being released, the version will already have been bumped with the highest bump type
+      let releasesFromUnfilteredChangesets = flattenReleases(
+        unfilteredChangesets,
+        workspacesByName
+      );
+
+      releases.forEach((value, key) => {
+        let releaseFromUnfilteredChangesets = releasesFromUnfilteredChangesets.get(
+          key
+        );
+        if (releaseFromUnfilteredChangesets === undefined) {
+          throw new InternalError(
+            "releaseFromUnfilteredChangesets is undefined"
+          );
+        }
+
+        releases.set(key, {
+          ...value,
+          // note that we're only setting the type, not the changesets which could be different(the name and oldVersion would be the same so they don't matter)
+          // because the changesets on a given release refer to why a given package is being released
+          // NOT why it's being released with a given bump type
+          // (the bump type could change because of this, linked or peer dependencies)
+          type: releaseFromUnfilteredChangesets.type
+        });
+      });
     }
   }
 
@@ -152,13 +154,13 @@ function assembleReleasePlan(
     // The map passed in to determineDependents will be mutated
     let dependentAdded = determineDependents(
       releases,
-      workspaces,
+      workspacesByName,
       dependentsGraph,
       preInfo
     );
 
     // The map passed in to determineDependents will be mutated
-    let linksUpdated = applyLinks(releases, workspaces, config.linked);
+    let linksUpdated = applyLinks(releases, workspacesByName, config.linked);
 
     releaseObjectValidated = !linksUpdated && !dependentAdded;
   }

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -586,4 +586,52 @@ describe("pre", () => {
       }
     ]);
   });
+  it("should work for my other weird case", async () => {
+    let cwd = f.copy("simple-project");
+    await writeChangeset(
+      {
+        releases: [{ name: "pkg-a", type: "major" }],
+        summary: "a very useful summary for the first change"
+      },
+      cwd
+    );
+
+    await pre(cwd, { command: "enter", tag: "next" });
+    await version(cwd, modifiedDefaultConfig);
+    let workspaces = (await getWorkspaces({ cwd }))!;
+
+    expect(workspaces.map(x => x.config)).toEqual([
+      {
+        dependencies: { "pkg-b": "1.0.0" },
+        name: "pkg-a",
+        version: "2.0.0-next.0"
+      },
+      {
+        name: "pkg-b",
+        version: "1.0.0"
+      }
+    ]);
+
+    await writeChangeset(
+      {
+        releases: [{ name: "pkg-a", type: "minor" }],
+        summary: "a very useful summary for the second change"
+      },
+      cwd
+    );
+    await version(cwd, modifiedDefaultConfig);
+    workspaces = (await getWorkspaces({ cwd }))!;
+
+    expect(workspaces.map(x => x.config)).toEqual([
+      {
+        dependencies: { "pkg-b": "1.0.0" },
+        name: "pkg-a",
+        version: "2.0.0-next.1"
+      },
+      {
+        name: "pkg-b",
+        version: "1.0.0"
+      }
+    ]);
+  });
 });

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -586,7 +586,7 @@ describe("pre", () => {
       }
     ]);
   });
-  it("should use the highest bump type for between all prereleases for every prerelease", async () => {
+  it.only("should use the highest bump type for between all prereleases for every prerelease", async () => {
     let cwd = f.copy("simple-project");
     await writeChangeset(
       {

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -586,7 +586,7 @@ describe("pre", () => {
       }
     ]);
   });
-  it("should work for my other weird case", async () => {
+  it("should use the highest bump type for between all prereleases for every prerelease", async () => {
     let cwd = f.copy("simple-project");
     await writeChangeset(
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2834,6 +2834,15 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
+get-workspaces@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/get-workspaces/-/get-workspaces-0.5.2.tgz#4fb2031ec1bdd32d3c1f3de2589ce8af5c2e24ee"
+  integrity sha512-99x72taQ9OUHhCmBS0B2WI/zwOtBOBPoyVNGs9+B0ag2GGhCjl/EaU9VQ8Zorx64TyVj1Am7bO+0J1KwDqo7OA==
+  dependencies:
+    "@changesets/types" "^0.4.0"
+    fs-extra "^7.0.1"
+    globby "^9.2.0"
+
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"


### PR DESCRIPTION
Closes #244