### PR TITLE
add ">=" to get-version-range-type

### DIFF
--- a/.changeset/tender-berries-change.md
+++ b/.changeset/tender-berries-change.md
@@ -1,0 +1,5 @@
+---
+"@changesets/get-version-range-type": minor
+---
+
+add ">=" to get-version-range-type

--- a/packages/get-version-range-type/src/index.ts
+++ b/packages/get-version-range-type/src/index.ts
@@ -3,6 +3,6 @@ export default function getVersionRangeType(
 ): "^" | "~" | ">=" | "" {
   if (versionRange.charAt(0) === "^") return "^";
   if (versionRange.charAt(0) === "~") return "~";
-  if (versionRange.charAt(0) === ">=") return ">=";
+  if (versionRange.startsWith(">=")) return ">=";
   return "";
 }

--- a/packages/get-version-range-type/src/index.ts
+++ b/packages/get-version-range-type/src/index.ts
@@ -1,7 +1,8 @@
 export default function getVersionRangeType(
   versionRange: string
-): "^" | "~" | "" {
+): "^" | "~" | ">=" | "" {
   if (versionRange.charAt(0) === "^") return "^";
   if (versionRange.charAt(0) === "~") return "~";
+  if (versionRange.charAt(0) === ">=") return ">=";
   return "";
 }


### PR DESCRIPTION
This is to workaround https://github.com/atlassian/changesets/issues/230, which is good enough for now since we can dedupe the versions within our own lockfile.

Also related:
https://github.com/atlassian/changesets/issues/99