### PR TITLE
Fix readme typo

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -106,7 +106,7 @@ changeset add [--empty]
 
 This command will ask you a series of questions, first about what packages you want to release, then what semver bump type for each package, then it will ask for a summary of the entire changeset. At the final step it will show the changeset it will generate, and confirm that you want to add it.
 
-Once confirmed, the changeset will be write a Markdown file that contains the summary and YAML front matter which stores the packages that will be released and the semester bump types for them.
+Once confirmed, the changeset will be write a Markdown file that contains the summary and YAML front matter which stores the packages that will be released and the semver bump types for them.
 
 A changeset that major bumps `@changesets/cli` would look like this:
 


### PR DESCRIPTION
This change updates a small typo in the add command readme section from `semester` to `semver`.

Let me know if this is actually intentional and we can close the PR 👍