### PR TITLE
Handle missing package.json

### DIFF
--- a/packages/get-workspaces/src/index.test.ts
+++ b/packages/get-workspaces/src/index.test.ts
@@ -77,7 +77,7 @@ describe("get-workspaces", () => {
   it("should return an empty array if package.json is missing", async () => {
     let cwd = await getFixturePath(__dirname, "empty");
     const workspaces = await getWorkspaces({ cwd });
-    expect(workspaces).toEqual(null);
+    expect(workspaces).toEqual([]);
   });
   it("should return an empty array if no workspaces are found", async () => {
     let cwd = await getFixturePath(__dirname, "root-only");

--- a/packages/get-workspaces/src/index.test.ts
+++ b/packages/get-workspaces/src/index.test.ts
@@ -74,6 +74,11 @@ describe("get-workspaces", () => {
     expect(workspaces[0].name).toEqual("pnpm-workspace-base-pkg-a");
     expect(workspaces[1].name).toEqual("pnpm-workspace-base-pkg-b");
   });
+  it("should return an empty array if package.json is missing", async () => {
+    let cwd = await getFixturePath(__dirname, "empty");
+    const workspaces = await getWorkspaces({ cwd });
+    expect(workspaces).toEqual(null);
+  });
   it("should return an empty array if no workspaces are found", async () => {
     let cwd = await getFixturePath(__dirname, "root-only");
     const workspaces = await getWorkspaces({ cwd });

--- a/packages/get-workspaces/src/index.ts
+++ b/packages/get-workspaces/src/index.ts
@@ -22,7 +22,7 @@ export default async function getWorkspaces(
   const tools = opts.tools || ["yarn", "bolt", "pnpm"]; // We also support root, but don't do it by default
 
   if (!fs.existsSync(path.join(cwd, "package.json"))) {
-    return null
+    return null;
   }
 
   const pkg = await fs

--- a/packages/get-workspaces/src/index.ts
+++ b/packages/get-workspaces/src/index.ts
@@ -22,7 +22,7 @@ export default async function getWorkspaces(
   const tools = opts.tools || ["yarn", "bolt", "pnpm"]; // We also support root, but don't do it by default
 
   if (!fs.existsSync(path.join(cwd, "package.json"))) {
-    return null;
+    return [];
   }
 
   const pkg = await fs

--- a/packages/get-workspaces/src/index.ts
+++ b/packages/get-workspaces/src/index.ts
@@ -21,6 +21,10 @@ export default async function getWorkspaces(
   const cwd = opts.cwd || process.cwd();
   const tools = opts.tools || ["yarn", "bolt", "pnpm"]; // We also support root, but don't do it by default
 
+  if (!fs.existsSync(path.join(cwd, "package.json"))) {
+    return null
+  }
+
   const pkg = await fs
     .readFile(path.join(cwd, "package.json"), "utf-8")
     .then(JSON.parse);


### PR DESCRIPTION
Currently a missing package.json leads to a file not found error. But for tests it is useful to also be able to run get-workspaces on a folder without a package.json. This PR returns an empty array instead.