### PR TITLE
Replace null by empty array

### DIFF
--- a/.changeset/twenty-days-relate.md
+++ b/.changeset/twenty-days-relate.md
@@ -1,0 +1,5 @@
+---
+"get-workspaces": major
+---
+
+Replace null by empty array

--- a/packages/get-workspaces/src/index.test.ts
+++ b/packages/get-workspaces/src/index.test.ts
@@ -5,79 +5,55 @@ describe("get-workspaces", () => {
   it("should resolve yarn workspaces if the yarn option is passed", async () => {
     let cwd = await getFixturePath(__dirname, "yarn-workspace-base");
     const workspaces = await getWorkspaces({ cwd, tools: ["yarn"] });
-    if (workspaces === null) {
-      return expect(workspaces).not.toBeNull();
-    }
     expect(workspaces[0].name).toEqual("yarn-workspace-base-pkg-a");
     expect(workspaces[1].name).toEqual("yarn-workspace-base-pkg-b");
   });
   it("should resolve yarn workspaces if the yarn option is passed and packages field is used", async () => {
     let cwd = await getFixturePath(__dirname, "yarn-workspace-packages");
     const workspaces = await getWorkspaces({ cwd, tools: ["yarn"] });
-    if (workspaces === null) {
-      return expect(workspaces).not.toBeNull();
-    }
     expect(workspaces[0].name).toEqual("yarn-workspace-package-pkg-a");
     expect(workspaces[1].name).toEqual("yarn-workspace-package-pkg-b");
   });
   it("should resolve bolt workspaces if the bolt option is passed", async () => {
     let cwd = await getFixturePath(__dirname, "bolt-workspace");
     const workspaces = await getWorkspaces({ cwd, tools: ["bolt"] });
-    if (workspaces === null) {
-      return expect(workspaces).not.toBeNull();
-    }
     expect(workspaces[0].name).toEqual("bolt-workspace-pkg-a");
     expect(workspaces[1].name).toEqual("bolt-workspace-pkg-b");
   });
   it("should resolve pnpm workspaces if the pnpm option is passed", async () => {
     let cwd = await getFixturePath(__dirname, "pnpm-workspace-base");
     const workspaces = await getWorkspaces({ cwd, tools: ["pnpm"] });
-    if (workspaces === null) {
-      return expect(workspaces).not.toBeNull();
-    }
     expect(workspaces[0].name).toEqual("pnpm-workspace-base-pkg-a");
     expect(workspaces[1].name).toEqual("pnpm-workspace-base-pkg-b");
   });
   it("should resolve main package if root option is passed", async () => {
     let cwd = await getFixturePath(__dirname, "root-only");
     const workspaces = await getWorkspaces({ cwd, tools: ["root"] });
-    if (workspaces === null) {
-      return expect(workspaces).not.toBeNull();
-    }
     expect(workspaces.length).toEqual(1);
     expect(workspaces[0].dir).toEqual(cwd);
   });
   it("should by default resolve yarn workspaces", async () => {
     let cwd = await getFixturePath(__dirname, "yarn-workspace-base");
     const workspaces = await getWorkspaces({ cwd });
-    if (workspaces === null) {
-      return expect(workspaces).not.toBeNull();
-    }
     expect(workspaces[0].name).toEqual("yarn-workspace-base-pkg-a");
     expect(workspaces[1].name).toEqual("yarn-workspace-base-pkg-b");
   });
   it("should by default resolve bolt workspaces if yarn workspaces are absent", async () => {
     let cwd = await getFixturePath(__dirname, "bolt-workspace");
     const workspaces = await getWorkspaces({ cwd });
-    if (workspaces === null) {
-      return expect(workspaces).not.toBeNull();
-    }
     expect(workspaces[0].name).toEqual("bolt-workspace-pkg-a");
     expect(workspaces[1].name).toEqual("bolt-workspace-pkg-b");
   });
   it("should by default resolve pnpm workspaces if yarn & bolt workspaces are absent", async () => {
     let cwd = await getFixturePath(__dirname, "pnpm-workspace-base");
     const workspaces = await getWorkspaces({ cwd });
-    if (workspaces === null) {
-      return expect(workspaces).not.toBeNull();
-    }
     expect(workspaces[0].name).toEqual("pnpm-workspace-base-pkg-a");
     expect(workspaces[1].name).toEqual("pnpm-workspace-base-pkg-b");
   });
   it("should return an empty array if no workspaces are found", async () => {
     let cwd = await getFixturePath(__dirname, "root-only");
     const workspaces = await getWorkspaces({ cwd });
-    expect(workspaces).toEqual(null);
+    expect(workspaces).toEqual([]);
   });
 
   it("should throw an error if a package.json is missing the name field", async () => {

--- a/packages/get-workspaces/src/index.ts
+++ b/packages/get-workspaces/src/index.ts
@@ -17,7 +17,7 @@ export type Workspace = { config: PackageJSON; name: string; dir: string };
 
 export default async function getWorkspaces(
   opts: Options = {}
-): Promise<Array<Workspace> | null> {
+): Promise<Array<Workspace>> {
   const cwd = opts.cwd || process.cwd();
   const tools = opts.tools || ["yarn", "bolt", "pnpm"]; // We also support root, but don't do it by default
 
@@ -54,7 +54,7 @@ export default async function getWorkspaces(
     if (tools.includes("root")) {
       return [{ config: pkg, dir: cwd, name: pkg.name }];
     }
-    return null;
+    return [];
   }
 
   const folders = await globby(workspaces, {


### PR DESCRIPTION
Currently the getWorkspaces function returns null in some cases. This makes the API much harder to use because the null case needs to be handled separately. Also, in the tests it already mentions that empty array should be returned. This PR returns empty arrays instead of null.