### PR TITLE
chore: add changeset to release new version of @changeset/types

### DIFF
--- a/.changeset/slimy-planets-know.md
+++ b/.changeset/slimy-planets-know.md
@@ -1,0 +1,5 @@
+---
+"@changesets/types": patch
+---
+
+add baseBranch to config


### PR DESCRIPTION
Looks like the `@changeset/types` package has unreleased changes.

Use the following steps to check:

```bash
mkdir test && cd test
npm init -y
npm install --save @changesets/types

cat ./node_modules/@changesets/types/dist/declarations/src/index.d.ts
```

You'll see that the `Config` type is missing the `baseBranch` key.