### PR TITLE
fix(changelog-github): Throw descriptive error when no options

### DIFF
--- a/.changeset/sour-hats-hear.md
+++ b/.changeset/sour-hats-hear.md
@@ -1,0 +1,6 @@
+---
+"@changesets/changelog-github": patch
+"@changesets/types": patch
+---
+
+In changelog-github, throw more descriptive error when no options are provided.

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -39,7 +39,7 @@ const changelogFunctions: ChangelogFunctions = {
     return [changesetLink, ...updatedDepenenciesList].join("\n");
   },
   getReleaseLine: async (changeset, type, options) => {
-    if (!options.repo) {
+    if (!options || !options.repo) {
       throw new Error(
         'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]'
       );

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -81,7 +81,7 @@ export type ModCompWithPackage = ComprehensiveRelease & {
 export type GetReleaseLine = (
   changeset: NewChangesetWithCommit,
   type: VersionType,
-  changelogOpts: any
+  changelogOpts: null | Record<string, any>
 ) => Promise<string>;
 
 export type GetDependencyReleaseLine = (


### PR DESCRIPTION
It's somewhat easy to find what you did wrong when using `"changelog": "@changesets/changelog-github"` since the offending line is included in the error but throwing the intended error instead would help even more.