### PR TITLE
Use longest path to determine package

### DIFF
--- a/.changeset/green-buttons-switch.md
+++ b/.changeset/green-buttons-switch.md
@@ -2,4 +2,4 @@
 "@changesets/git": patch
 ---
 
-Previously monorepo package may be considered as changed package instead of actually changed one. Now git package is looking for the longest package.dir path that satisfies condition
+Previously packages nested inside of other packages would show both the nested package and the outer package as changed. Now, only the nested package will show as changed.

--- a/.changeset/green-buttons-switch.md
+++ b/.changeset/green-buttons-switch.md
@@ -1,0 +1,5 @@
+---
+"@changesets/git": patch
+---
+
+Previously monorepo package may be considered as changed package instead of actually changed one. Now git package is looking for the longest package.dir path that satisfies condition

--- a/__fixtures__/with-git/package.json
+++ b/__fixtures__/with-git/package.json
@@ -5,6 +5,7 @@
   "version": "1.0.0",
   "bolt": {
     "workspaces": [
+      "packages",
       "packages/*"
     ]
   }

--- a/__fixtures__/with-git/packages/package.json
+++ b/__fixtures__/with-git/packages/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "packages",
+  "version": "1.0.0"
+}
+  

--- a/__fixtures__/with-git/packages/package.json
+++ b/__fixtures__/with-git/packages/package.json
@@ -2,4 +2,3 @@
   "name": "packages",
   "version": "1.0.0"
 }
-  

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -115,11 +115,13 @@ describe("git", () => {
         .split("\n")
         .filter(a => a);
 
-      expect(stagedFiles).toHaveLength(4);
-      expect(stagedFiles[0]).toEqual("packages/pkg-a/index.js");
-      expect(stagedFiles[1]).toEqual("packages/pkg-a/package.json");
-      expect(stagedFiles[2]).toEqual("packages/pkg-b/index.js");
-      expect(stagedFiles[3]).toEqual("packages/pkg-b/package.json");
+      expect(stagedFiles).toEqual([
+        "packages/package.json",
+        "packages/pkg-a/index.js",
+        "packages/pkg-a/package.json",
+        "packages/pkg-b/index.js",
+        "packages/pkg-b/package.json"
+      ]);
     });
   });
 


### PR DESCRIPTION
I've added packages/package.json to fixture to simulate issue I'm having on own repository. After that a lot of tests started to fail. Fix in git/index.ts fixed all that tests. I assume there is no need to add some specific tests to that case since other ones cover this functionality
close #351