### PR TITLE
Fix #347 (there's not a spec, so link straight to dictionary from README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ If you just want to jump in to using changesets, the [@changesets/cli](./package
 If you want a detailed explanation of the the concepts behind changesets, or to understand how you would build on top
 of changesets, check out our [detailed-explanation](./docs/detailed-explanation.md).
 
-We also have a [spec](./docs/spec.md).
+We also have a [dictionary](./docs/dictionary.md).
+
 
 ## Integrating with CI
 

--- a/docs/detailed-explanation.md
+++ b/docs/detailed-explanation.md
@@ -1,7 +1,6 @@
 # A Detailed Explanation of Changesets
 
 Below, you will find a detailed explanation of what changesets are, and how they are being thought about.
-If you want to build tools that use changesets, I recommend checking out our [changesets spec](./spec.md).
 
 ## The problem:
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,3 +1,0 @@
-# Spec (WIP)
-
-Spec is cancelle - please see [dictonary](./dictionary.md) instead.


### PR DESCRIPTION
Fixes #347.

Since detailed-explanation.md still quite WIP, and I'm not qualified to rewrite anything in terms of concepts behind the project, I've removed sentence mentioning spec there. That's the last link, so spec.md is removed.