### PR TITLE
fix: handle errors when checking divergent branches

### DIFF
--- a/.changeset/hip-windows-doubt.md
+++ b/.changeset/hip-windows-doubt.md
@@ -1,0 +1,5 @@
+---
+"@changesets/git": patch
+---
+
+Fix an issue where refs that didn't exist were silently ignored

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -32,9 +32,14 @@ async function tag(tagStr: string, cwd: string) {
   return gitCmd.code === 0;
 }
 
+// Find the commit where we diverged from `ref` at using `git merge-base`
 export async function getDivergedCommit(cwd: string, ref: string) {
-  // First we need to find the commit where we diverged from `ref` at using `git merge-base`
   const cmd = await spawn("git", ["merge-base", ref, "HEAD"], { cwd });
+  if (cmd.code !== 0) {
+    throw new Error(
+      `Failed to find where HEAD diverged from ${ref}. Does ${ref} exist?`
+    );
+  }
   return cmd.stdout.toString().trim();
 }
 
@@ -59,6 +64,12 @@ async function getChangedFilesSince({
   const divergedAt = await getDivergedCommit(cwd, ref);
   // Now we can find which files we added
   const cmd = await spawn("git", ["diff", "--name-only", divergedAt], { cwd });
+  if (cmd.code !== 0) {
+    throw new Error(
+      `Failed to diff against ${divergedAt}. Is ${divergedAt} a valid ref?`
+    );
+  }
+
   const files = cmd.stdout
     .toString()
     .trim()


### PR DESCRIPTION
I just ran into the issue where my CI environment was performing a
shallow clone, and so it didn't have all the refs in its local copy.

When I used the `getReleasePlan(cwd, MY_CUSTOM_REF)` function, it
silently failed and returned an empty release plan.
It took me a while to figure out what the problem was!

This change adds error handling when we call out to `git`, so if the ref
itself doesn't actually exist then the function throws.