### PR TITLE
When logging successful releases and creating tags include an information about those being git tags

### DIFF
--- a/.changeset/gorgeous-insects-cheer.md
+++ b/.changeset/gorgeous-insects-cheer.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+When logging successful releases and creating tags include an information about those being git tags.

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -54,7 +54,7 @@ export default async function run(
     // We create the tags after the push above so that we know that HEAD wont change and that pushing
     // wont suffer from a race condition if another merge happens in the mean time (pushing tags wont
     // fail if we are behind master).
-    log("Creating tags...");
+    log("Creating git tags...");
     for (const pkg of successful) {
       const tag = `${pkg.name}@${pkg.newVersion}`;
       log("New tag: ", tag);


### PR DESCRIPTION
Just a minor thing - when reading logs for packages released in pre mode I wasn't immediately sure which tags this was referring to. This just makes this information more explicit.