### PR TITLE
Create a simple tag for single-package projects

### DIFF
--- a/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
@@ -2,6 +2,7 @@ import fixtures from "fixturez";
 
 import publishPackages from "../publishPackages";
 import * as npmUtils from "../npm-utils";
+import { getPackages } from "@manypkg/get-packages";
 
 jest.mock("../npm-utils");
 jest.mock("is-ci", () => true);
@@ -34,7 +35,11 @@ describe("publishPackages", () => {
 
   describe("when isCI", () => {
     it("does not call out to npm to see if otp is required", async () => {
-      await publishPackages({ cwd, access: "public", preState: undefined });
+      await publishPackages({
+        packages: (await getPackages(cwd)).packages,
+        access: "public",
+        preState: undefined
+      });
       expect(npmUtils.getTokenIsRequired).not.toHaveBeenCalled();
     });
   });

--- a/packages/cli/src/commands/publish/publishPackages.ts
+++ b/packages/cli/src/commands/publish/publishPackages.ts
@@ -1,7 +1,7 @@
 import semver from "semver";
 import chalk from "chalk";
 import { AccessType } from "@changesets/types";
-import { getPackages, Package } from "@manypkg/get-packages";
+import { Package } from "@manypkg/get-packages";
 import * as npmUtils from "./npm-utils";
 import { info, warn } from "@changesets/logger";
 import { TwoFactorState } from "../../utils/types";
@@ -19,25 +19,20 @@ function getReleaseTag(pkgInfo: PkgInfo, preState?: PreState, tag?: string) {
 }
 
 export default async function publishPackages({
-  cwd,
+  packages,
   access,
   otp,
   preState,
   tag
 }: {
-  cwd: string;
+  packages: Package[];
   access: AccessType;
   otp?: string;
   preState: PreState | undefined;
   tag?: string;
 }) {
-  const packages = await getPackages(cwd);
-  const packagesByName = new Map(
-    packages.packages.map(x => [x.packageJson.name, x])
-  );
-  const publicPackages = packages.packages.filter(
-    pkg => !pkg.packageJson.private
-  );
+  const packagesByName = new Map(packages.map(x => [x.packageJson.name, x]));
+  const publicPackages = packages.filter(pkg => !pkg.packageJson.private);
   let twoFactorState: TwoFactorState =
     otp === undefined
       ? {


### PR DESCRIPTION
For single-package projects including package name in the created tag name is not necessary and actually also hurts discoverability as those tags don't pop up for some reason in the tags dropdown on GitHub. 

The proposed tag matches `npm version` scheme.

If I get a preliminary approval for this then I'm going to add a changeset and fix tests.