### PR TITLE
Add an experimental option `useCalculatedVersionForSnapshots`

### DIFF
--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -78,7 +78,8 @@ async function testSetup(
       baseBranch: "master",
       updateInternalDependencies: "patch",
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-        onlyUpdatePeerDependentsWhenOutOfRange: false
+        onlyUpdatePeerDependentsWhenOutOfRange: false,
+        useCalculatedVersionForSnapshots: false
       }
     };
   }
@@ -283,7 +284,8 @@ describe("apply release plan", () => {
           baseBranch: "master",
           updateInternalDependencies: "patch",
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-            onlyUpdatePeerDependentsWhenOutOfRange: false
+            onlyUpdatePeerDependentsWhenOutOfRange: false,
+            useCalculatedVersionForSnapshots: false
           }
         }
       );
@@ -342,7 +344,8 @@ describe("apply release plan", () => {
           baseBranch: "master",
           updateInternalDependencies: "patch",
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-            onlyUpdatePeerDependentsWhenOutOfRange: false
+            onlyUpdatePeerDependentsWhenOutOfRange: false,
+            useCalculatedVersionForSnapshots: false
           }
         }
       );
@@ -405,7 +408,8 @@ describe("apply release plan", () => {
               baseBranch: "master",
               updateInternalDependencies,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-                onlyUpdatePeerDependentsWhenOutOfRange: false
+                onlyUpdatePeerDependentsWhenOutOfRange: false,
+                useCalculatedVersionForSnapshots: false
               }
             }
           );
@@ -486,7 +490,8 @@ describe("apply release plan", () => {
               baseBranch: "master",
               updateInternalDependencies,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-                onlyUpdatePeerDependentsWhenOutOfRange: false
+                onlyUpdatePeerDependentsWhenOutOfRange: false,
+                useCalculatedVersionForSnapshots: false
               }
             }
           );
@@ -559,7 +564,8 @@ describe("apply release plan", () => {
               baseBranch: "master",
               updateInternalDependencies,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-                onlyUpdatePeerDependentsWhenOutOfRange: false
+                onlyUpdatePeerDependentsWhenOutOfRange: false,
+                useCalculatedVersionForSnapshots: false
               }
             }
           );
@@ -632,7 +638,8 @@ describe("apply release plan", () => {
               baseBranch: "master",
               updateInternalDependencies,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-                onlyUpdatePeerDependentsWhenOutOfRange: false
+                onlyUpdatePeerDependentsWhenOutOfRange: false,
+                useCalculatedVersionForSnapshots: false
               }
             }
           );
@@ -708,7 +715,8 @@ describe("apply release plan", () => {
               baseBranch: "master",
               updateInternalDependencies,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-                onlyUpdatePeerDependentsWhenOutOfRange: false
+                onlyUpdatePeerDependentsWhenOutOfRange: false,
+                useCalculatedVersionForSnapshots: false
               }
             }
           );
@@ -789,7 +797,8 @@ describe("apply release plan", () => {
               baseBranch: "master",
               updateInternalDependencies,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-                onlyUpdatePeerDependentsWhenOutOfRange: false
+                onlyUpdatePeerDependentsWhenOutOfRange: false,
+                useCalculatedVersionForSnapshots: false
               }
             }
           );
@@ -862,7 +871,8 @@ describe("apply release plan", () => {
               baseBranch: "master",
               updateInternalDependencies,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-                onlyUpdatePeerDependentsWhenOutOfRange: false
+                onlyUpdatePeerDependentsWhenOutOfRange: false,
+                useCalculatedVersionForSnapshots: false
               }
             }
           );
@@ -935,7 +945,8 @@ describe("apply release plan", () => {
               baseBranch: "master",
               updateInternalDependencies,
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-                onlyUpdatePeerDependentsWhenOutOfRange: false
+                onlyUpdatePeerDependentsWhenOutOfRange: false,
+                useCalculatedVersionForSnapshots: false
               }
             }
           );
@@ -1168,7 +1179,8 @@ describe("apply release plan", () => {
           ],
           updateInternalDependencies: "patch",
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-            onlyUpdatePeerDependentsWhenOutOfRange: false
+            onlyUpdatePeerDependentsWhenOutOfRange: false,
+            useCalculatedVersionForSnapshots: false
           }
         }
       );
@@ -1269,7 +1281,8 @@ describe("apply release plan", () => {
           baseBranch: "master",
           updateInternalDependencies: "patch",
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-            onlyUpdatePeerDependentsWhenOutOfRange: false
+            onlyUpdatePeerDependentsWhenOutOfRange: false,
+            useCalculatedVersionForSnapshots: false
           }
         }
       );
@@ -1348,7 +1361,8 @@ describe("apply release plan", () => {
           baseBranch: "master",
           updateInternalDependencies: "minor",
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-            onlyUpdatePeerDependentsWhenOutOfRange: false
+            onlyUpdatePeerDependentsWhenOutOfRange: false,
+            useCalculatedVersionForSnapshots: false
           }
         }
       );
@@ -1431,7 +1445,8 @@ describe("apply release plan", () => {
           baseBranch: "master",
           updateInternalDependencies: "minor",
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-            onlyUpdatePeerDependentsWhenOutOfRange: false
+            onlyUpdatePeerDependentsWhenOutOfRange: false,
+            useCalculatedVersionForSnapshots: false
           }
         }
       );
@@ -1527,7 +1542,8 @@ describe("apply release plan", () => {
           baseBranch: "master",
           updateInternalDependencies: "minor",
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-            onlyUpdatePeerDependentsWhenOutOfRange: false
+            onlyUpdatePeerDependentsWhenOutOfRange: false,
+            useCalculatedVersionForSnapshots: false
           }
         }
       );
@@ -1898,7 +1914,8 @@ describe("apply release plan", () => {
           baseBranch: "master",
           updateInternalDependencies: "patch",
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-            onlyUpdatePeerDependentsWhenOutOfRange: false
+            onlyUpdatePeerDependentsWhenOutOfRange: false,
+            useCalculatedVersionForSnapshots: false
           }
         }
       );

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -1023,7 +1023,8 @@ describe("apply release plan", () => {
             baseBranch: "master",
             updateInternalDependencies: "patch",
             ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-              onlyUpdatePeerDependentsWhenOutOfRange: true
+              onlyUpdatePeerDependentsWhenOutOfRange: true,
+              useCalculatedVersionForSnapshots: false
             }
           }
         );

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -45,7 +45,8 @@ class FakeReleasePlan {
       baseBranch: "master",
       updateInternalDependencies: "patch",
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-        onlyUpdatePeerDependentsWhenOutOfRange: false
+        onlyUpdatePeerDependentsWhenOutOfRange: false,
+        useCalculatedVersionForSnapshots: false
       }
     };
 

--- a/packages/assemble-release-plan/src/determine-dependents.ts
+++ b/packages/assemble-release-plan/src/determine-dependents.ts
@@ -75,6 +75,10 @@ export default function getDependents({
             (releases.has(dependent) &&
               releases.get(dependent)!.type !== "major"))
         ) {
+          console.log("really?", versionRange, incrementVersion(nextRelease, preInfo), semver.satisfies(
+            incrementVersion(nextRelease, preInfo),
+            versionRange
+          ));
           type = "major";
         } else {
           if (

--- a/packages/assemble-release-plan/src/determine-dependents.ts
+++ b/packages/assemble-release-plan/src/determine-dependents.ts
@@ -75,10 +75,6 @@ export default function getDependents({
             (releases.has(dependent) &&
               releases.get(dependent)!.type !== "major"))
         ) {
-          console.log("really?", versionRange, incrementVersion(nextRelease, preInfo), semver.satisfies(
-            incrementVersion(nextRelease, preInfo),
-            versionRange
-          ));
           type = "major";
         } else {
           if (

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -618,7 +618,8 @@ describe("bumping peerDeps", () => {
         {
           ...defaultConfig,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-            onlyUpdatePeerDependentsWhenOutOfRange: true
+            onlyUpdatePeerDependentsWhenOutOfRange: true,
+            useCalculatedVersionForSnapshots: false
           }
         },
         undefined
@@ -642,7 +643,8 @@ describe("bumping peerDeps", () => {
       {
         ...defaultConfig,
         ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-          onlyUpdatePeerDependentsWhenOutOfRange: true
+          onlyUpdatePeerDependentsWhenOutOfRange: true,
+          useCalculatedVersionForSnapshots: false
         }
       },
       undefined

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -612,7 +612,6 @@ describe("bumping peerDeps", () => {
         id: "anyway-the-windblows",
         releases: [{ name: "pkg-a", type: "minor" }]
       });
-
       let { releases } = assembleReleasePlan(
         setup.changesets,
         setup.packages,
@@ -624,7 +623,6 @@ describe("bumping peerDeps", () => {
         },
         undefined
       );
-
       expect(releases.length).toBe(1);
       expect(releases[0].name).toEqual("pkg-a");
       expect(releases[0].newVersion).toEqual("1.1.0");

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -52,7 +52,7 @@ function getNewVersion(
    * if user has a regular pre-release at 1.0.0-beta.0 and then you had a snapshot pre-release at 1.0.0-canary-git-hash
    * and a consumer is using the range ^1.0.0-beta, most people would expect that range to resolve to 1.0.0-beta.0
    * but it'll actually resolve to 1.0.0-canary-hash. Using 0.0.0 solves this problem because it won't conflict with other versions.
-   * 
+   *
    * You can set `useCalculatedVersionForSnapshots` flag to true to use calculated versions if you don't care about the above problem.
    */
   if (snapshot && !useCalculatedVersionForSnapshots) {
@@ -62,7 +62,7 @@ function getNewVersion(
   const calculatedVersion = incrementVersion(release, preInfo);
 
   if (snapshot && useCalculatedVersionForSnapshots) {
-    return `${calculatedVersion}${snapshotSuffix}`
+    return `${calculatedVersion}${snapshotSuffix}`;
   }
 
   return calculatedVersion;
@@ -79,11 +79,11 @@ function assembleReleasePlan(
     preState === undefined
       ? undefined
       : {
-        ...preState,
-        initialVersions: {
-          ...preState.initialVersions
-        }
-      };
+          ...preState,
+          initialVersions: {
+            ...preState.initialVersions
+          }
+        };
 
   // Caching the snapshot version here and use this if it is snapshot release
   let snapshotSuffix: string;
@@ -204,9 +204,9 @@ function assembleReleasePlan(
     updatedPreState === undefined
       ? undefined
       : {
-        state: updatedPreState,
-        preVersions
-      };
+          state: updatedPreState,
+          preVersions
+        };
 
   let dependencyGraph = getDependentsGraph(packages);
 
@@ -239,7 +239,8 @@ function assembleReleasePlan(
           preInfo,
           snapshot,
           snapshotSuffix,
-          config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.useCalculatedVersionForSnapshots
+          config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
+            .useCalculatedVersionForSnapshots
         )
       };
     }),

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -239,7 +239,7 @@ function assembleReleasePlan(
           preInfo,
           snapshot,
           snapshotSuffix,
-          config._experimentalUnsafeOptions.onlyUpdatePeerDependentsWhenOutOfRange
+          config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.useCalculatedVersionForSnapshots
         )
       };
     }),

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -8,7 +8,6 @@ import { InternalError } from "@changesets/errors";
 import { Packages } from "@manypkg/get-packages";
 import { getDependentsGraph } from "@changesets/get-dependents-graph";
 import { PreInfo, InternalRelease } from "./types";
-import pre from "../../cli/src/commands/pre";
 
 function getPreVersion(version: string) {
   let parsed = semver.parse(version)!;

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -7,7 +7,8 @@ import * as semver from "semver";
 import { InternalError } from "@changesets/errors";
 import { Packages } from "@manypkg/get-packages";
 import { getDependentsGraph } from "@changesets/get-dependents-graph";
-import { PreInfo } from "./types";
+import { PreInfo, InternalRelease } from "./types";
+import pre from "../../cli/src/commands/pre";
 
 function getPreVersion(version: string) {
   let parsed = semver.parse(version)!;
@@ -20,14 +21,7 @@ function getPreVersion(version: string) {
   return preVersion;
 }
 
-/**
- * Using version as 0.0.0 so that it does not hinder with other version release
- * For example;
- * if user has a regular pre-release at 1.0.0-beta.0 and then you had a snapshot pre-release at 1.0.0-canary-git-hash
- * and a consumer is using the range ^1.0.0-beta, most people would expect that range to resolve to 1.0.0-beta.0
- * but it'll actually resolve to 1.0.0-canary-hash. Using 0.0.0 solves this problem because it won't conflict with other versions.
- */
-function getSnapshotReleaseVersion(snapshot?: string | boolean) {
+function getSnapshotSuffix(snapshot?: string | boolean): string {
   const now = new Date();
 
   let dateAndTime = [
@@ -42,7 +36,36 @@ function getSnapshotReleaseVersion(snapshot?: string | boolean) {
   let tag = "";
   if (typeof snapshot === "string") tag = `-${snapshot}`;
 
-  return `0.0.0${tag}-${dateAndTime}`;
+  return `${tag}-${dateAndTime}`;
+}
+
+function getNewVersion(
+  release: InternalRelease,
+  preInfo: PreInfo | undefined,
+  snapshot: string | boolean | undefined,
+  snapshotSuffix: string,
+  useCalculatedVersionForSnapshots: boolean
+): string {
+  /**
+   * Using version as 0.0.0 so that it does not hinder with other version release
+   * For example;
+   * if user has a regular pre-release at 1.0.0-beta.0 and then you had a snapshot pre-release at 1.0.0-canary-git-hash
+   * and a consumer is using the range ^1.0.0-beta, most people would expect that range to resolve to 1.0.0-beta.0
+   * but it'll actually resolve to 1.0.0-canary-hash. Using 0.0.0 solves this problem because it won't conflict with other versions.
+   * 
+   * You can set `useCalculatedVersionForSnapshots` flag to true to use calculated versions if you don't care about the above problem.
+   */
+  if (snapshot && !useCalculatedVersionForSnapshots) {
+    return `0.0.0${snapshotSuffix}`;
+  }
+
+  const calculatedVersion = incrementVersion(release, preInfo);
+
+  if (snapshot && useCalculatedVersionForSnapshots) {
+    return `${calculatedVersion}${snapshotSuffix}`
+  }
+
+  return calculatedVersion;
 }
 
 function assembleReleasePlan(
@@ -56,16 +79,16 @@ function assembleReleasePlan(
     preState === undefined
       ? undefined
       : {
-          ...preState,
-          initialVersions: {
-            ...preState.initialVersions
-          }
-        };
+        ...preState,
+        initialVersions: {
+          ...preState.initialVersions
+        }
+      };
 
   // Caching the snapshot version here and use this if it is snapshot release
-  let snapshotVersion: string;
+  let snapshotSuffix: string;
   if (snapshot !== undefined) {
-    snapshotVersion = getSnapshotReleaseVersion(snapshot);
+    snapshotSuffix = getSnapshotSuffix(snapshot);
   }
 
   let packagesByName = new Map(
@@ -181,9 +204,9 @@ function assembleReleasePlan(
     updatedPreState === undefined
       ? undefined
       : {
-          state: updatedPreState,
-          preVersions
-        };
+        state: updatedPreState,
+        preVersions
+      };
 
   let dependencyGraph = getDependentsGraph(packages);
 
@@ -211,10 +234,13 @@ function assembleReleasePlan(
     releases: [...releases.values()].map(incompleteRelease => {
       return {
         ...incompleteRelease,
-        newVersion:
-          snapshot === undefined
-            ? incrementVersion(incompleteRelease, preInfo)!
-            : snapshotVersion
+        newVersion: getNewVersion(
+          incompleteRelease,
+          preInfo,
+          snapshot,
+          snapshotSuffix,
+          config._experimentalUnsafeOptions.onlyUpdatePeerDependentsWhenOutOfRange
+        )
       };
     }),
     preState: updatedPreState

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -311,6 +311,41 @@ describe("snapshot release", () => {
       })
     );
   });
+
+  describe("useCalculatedVersionForSnapshots: true", () => {
+    it("should update packages using calculated version", async () => {
+      let cwd = f.copy("simple-project");
+      await writeChangesets([simpleChangeset2], cwd);
+      const spy = jest.spyOn(fs, "writeFile");
+      await versionCommand(
+        cwd,
+        {
+          snapshot: "exprimental"
+        },
+        {
+          ...modifiedDefaultConfig,
+          commit: false,
+          ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+            onlyUpdatePeerDependentsWhenOutOfRange: false,
+            useCalculatedVersionForSnapshots: true
+          }
+        }
+      );
+      expect(getPkgJSON("pkg-a", spy.mock.calls)).toEqual(
+        expect.objectContaining({
+          name: "pkg-a",
+          version: expect.stringContaining("1.1.0-exprimental-")
+        })
+      );
+  
+      expect(getPkgJSON("pkg-b", spy.mock.calls)).toEqual(
+        expect.objectContaining({
+          name: "pkg-b",
+          version: expect.stringContaining("1.0.1-exprimental-")
+        })
+      );
+    });
+  });
 });
 
 describe("pre", () => {

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -337,7 +337,7 @@ describe("snapshot release", () => {
           version: expect.stringContaining("1.1.0-exprimental-")
         })
       );
-  
+
       expect(getPkgJSON("pkg-b", spy.mock.calls)).toEqual(
         expect.objectContaining({
           name: "pkg-b",

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -303,7 +303,7 @@ The \`onlyUpdatePeerDependentsWhenOutOfRange\` option is set as \\"not true\\" w
   test("useCalculatedVersionForSnapshots non-boolean", () => {
     expect(() => {
       unsafeParse({
-        _experimentalUnsafeOptions: {
+        ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
           useCalculatedVersionForSnapshots: "not true"
         }
       });

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -28,7 +28,8 @@ test("read reads the config", async () => {
     baseBranch: "master",
     updateInternalDependencies: "patch",
     ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-      onlyUpdatePeerDependentsWhenOutOfRange: false
+      onlyUpdatePeerDependentsWhenOutOfRange: false,
+      useCalculatedVersionForSnapshots: false
     }
   });
 });
@@ -41,7 +42,8 @@ let defaults = {
   baseBranch: "master",
   updateInternalDependencies: "patch",
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-    onlyUpdatePeerDependentsWhenOutOfRange: false
+    onlyUpdatePeerDependentsWhenOutOfRange: false,
+    useCalculatedVersionForSnapshots: false
   }
 } as const;
 

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -286,7 +286,6 @@ The package \\"pkg-a\\" is in multiple sets of linked packages. Packages can onl
 The \`updateInternalDependencies\` option is set as \\"major\\" but can only be 'patch' or 'minor'"
 `);
   });
-
   test("onlyUpdatePeerDependentsWhenOutOfRange non-boolean", () => {
     expect(() => {
       unsafeParse({
@@ -297,6 +296,18 @@ The \`updateInternalDependencies\` option is set as \\"major\\" but can only be 
     }).toThrowErrorMatchingInlineSnapshot(`
 "Some errors occurred when validating the changesets config:
 The \`onlyUpdatePeerDependentsWhenOutOfRange\` option is set as \\"not true\\" when the only valid values are undefined or a boolean"
+`);
+  });
+  test("useCalculatedVersionForSnapshots non-boolean", () => {
+    expect(() => {
+      unsafeParse({
+        _experimentalUnsafeOptions: {
+          useCalculatedVersionForSnapshots: "not true"
+        }
+      });
+    }).toThrowErrorMatchingInlineSnapshot(`
+"Some errors occurred when validating the changesets config:
+The \`useCalculatedVersionForSnapshots\` option is set as \\"not true\\" when the only valid values are undefined or a boolean"
 `);
   });
 });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -227,8 +227,8 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
               .onlyUpdatePeerDependentsWhenOutOfRange,
 
       useCalculatedVersionForSnapshots:
-      json._experimentalUnsafeOptions === undefined ||
-        json._experimentalUnsafeOptions
+      json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH === undefined ||
+        json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
           .useCalculatedVersionForSnapshots === undefined
         ? defaultWrittenConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
           .useCalculatedVersionForSnapshots

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -15,7 +15,8 @@ export let defaultWrittenConfig = {
   baseBranch: "master",
   updateInternalDependencies: "patch",
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-    onlyUpdatePeerDependentsWhenOutOfRange: false
+    onlyUpdatePeerDependentsWhenOutOfRange: false,
+    useCalculatedVersionForSnapshots: false
   }
 } as const;
 
@@ -157,7 +158,8 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
 
   if (json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH !== undefined) {
     const {
-      onlyUpdatePeerDependentsWhenOutOfRange
+      onlyUpdatePeerDependentsWhenOutOfRange,
+      useCalculatedVersionForSnapshots
     } = json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH;
     if (
       onlyUpdatePeerDependentsWhenOutOfRange !== undefined &&
@@ -171,11 +173,22 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
         )} when the only valid values are undefined or a boolean`
       );
     }
+    if (useCalculatedVersionForSnapshots !== undefined &&
+      typeof useCalculatedVersionForSnapshots !== "boolean"
+    ) {
+      messages.push(
+        `The \`useCalculatedVersionForSnapshots\` option is set as ${JSON.stringify(
+          useCalculatedVersionForSnapshots,
+          null,
+          2
+        )} when the only valid values are undefined or a boolean`
+      );
+    }
   }
   if (messages.length) {
     throw new ValidationError(
       `Some errors occurred when validating the changesets config:\n` +
-        messages.join("\n")
+      messages.join("\n")
     );
   }
   let config: Config = {
@@ -211,7 +224,16 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
               .___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
               .onlyUpdatePeerDependentsWhenOutOfRange
           : json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
-              .onlyUpdatePeerDependentsWhenOutOfRange
+              .onlyUpdatePeerDependentsWhenOutOfRange,
+
+      useCalculatedVersionForSnapshots:
+      json._experimentalUnsafeOptions === undefined ||
+        json._experimentalUnsafeOptions
+          .useCalculatedVersionForSnapshots === undefined
+        ? defaultWrittenConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
+          .useCalculatedVersionForSnapshots
+        : json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
+          .useCalculatedVersionForSnapshots
     }
   };
   return config;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -173,7 +173,8 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
         )} when the only valid values are undefined or a boolean`
       );
     }
-    if (useCalculatedVersionForSnapshots !== undefined &&
+    if (
+      useCalculatedVersionForSnapshots !== undefined &&
       typeof useCalculatedVersionForSnapshots !== "boolean"
     ) {
       messages.push(
@@ -188,7 +189,7 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
   if (messages.length) {
     throw new ValidationError(
       `Some errors occurred when validating the changesets config:\n` +
-      messages.join("\n")
+        messages.join("\n")
     );
   }
   let config: Config = {
@@ -227,13 +228,14 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
               .onlyUpdatePeerDependentsWhenOutOfRange,
 
       useCalculatedVersionForSnapshots:
-      json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH === undefined ||
+        json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH === undefined ||
         json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
           .useCalculatedVersionForSnapshots === undefined
-        ? defaultWrittenConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
-          .useCalculatedVersionForSnapshots
-        : json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
-          .useCalculatedVersionForSnapshots
+          ? defaultWrittenConfig
+              .___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
+              .useCalculatedVersionForSnapshots
+          : json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
+              .useCalculatedVersionForSnapshots
     }
   };
   return config;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -84,8 +84,8 @@ export type ExperimentalOptions = {
 };
 
 export type ExperimentalOptions = {
-  onlyUpdatePeerDependentsWhenOutOfRange: boolean
-}
+  onlyUpdatePeerDependentsWhenOutOfRange: boolean;
+};
 
 export type NewChangesetWithCommit = NewChangeset & { commit?: string };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -85,6 +85,7 @@ export type ExperimentalOptions = {
 
 export type ExperimentalOptions = {
   onlyUpdatePeerDependentsWhenOutOfRange?: boolean;
+  useCalculatedVersionForSnapshots?: boolean;
 };
 
 export type NewChangesetWithCommit = NewChangeset & { commit?: string };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -83,6 +83,10 @@ export type ExperimentalOptions = {
   onlyUpdatePeerDependentsWhenOutOfRange?: boolean;
 };
 
+export type ExperimentalOptions = {
+  onlyUpdatePeerDependentsWhenOutOfRange: boolean
+}
+
 export type NewChangesetWithCommit = NewChangeset & { commit?: string };
 
 export type ModCompWithPackage = ComprehensiveRelease & {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -84,7 +84,7 @@ export type ExperimentalOptions = {
 };
 
 export type ExperimentalOptions = {
-  onlyUpdatePeerDependentsWhenOutOfRange: boolean;
+  onlyUpdatePeerDependentsWhenOutOfRange?: boolean;
 };
 
 export type NewChangesetWithCommit = NewChangeset & { commit?: string };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -81,10 +81,6 @@ export type WrittenConfig = {
 
 export type ExperimentalOptions = {
   onlyUpdatePeerDependentsWhenOutOfRange?: boolean;
-};
-
-export type ExperimentalOptions = {
-  onlyUpdatePeerDependentsWhenOutOfRange?: boolean;
   useCalculatedVersionForSnapshots?: boolean;
 };
 


### PR DESCRIPTION
Implements https://github.com/atlassian/changesets/issues/381#issuecomment-636549738
Currently snapshot version always starts with `0.0.0`. The experimental option allows us to use the calculated version (the next version) instead of `0.0.0`. It is useful when you want to use snapshot for canary/pre releases while still communicating the intended next version.