### PR TITLE
Update config's JSON schema

### DIFF
--- a/.changeset/afraid-papayas-poke.md
+++ b/.changeset/afraid-papayas-poke.md
@@ -1,0 +1,5 @@
+---
+"@changesets/config": patch
+---
+
+Removed experimental flags from `defaultWrittenConfig`. They were added there by mistake.

--- a/.changeset/great-trains-look.md
+++ b/.changeset/great-trains-look.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+Fixed an issue with experimental flags being written to disk as part of the default config when initializing Changesets.

--- a/.changeset/nine-hairs-rescue.md
+++ b/.changeset/nine-hairs-rescue.md
@@ -1,0 +1,5 @@
+---
+"@changesets/config": minor
+---
+
+Added `updateInternalDependencies` and `ignore` options to the JSON schema.

--- a/packages/config/schema.json
+++ b/packages/config/schema.json
@@ -40,19 +40,33 @@
     },
     "commit": {
       "type": "boolean",
-      "description": "Determines whether Changesets should commit the results of the add and version command",
+      "description": "Determines whether Changesets should commit the results of the add and version command.",
       "default": false
     },
     "access": {
       "enum": ["restricted", "public"],
       "type": "string",
-      "description": "Determines whether Changesets should publish packages to the registry publicly or to a restricted scope",
+      "description": "Determines whether Changesets should publish packages to the registry publicly or to a restricted scope.",
       "default": "restricted"
     },
     "baseBranch": {
       "type": "string",
       "default": "master",
-      "description": "Determines the branch that Changesets uses when finding what packages have changed"
+      "description": "Determines the branch that Changesets uses when finding what packages have changed."
+    },
+    "ignore": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Packages that should not be released.",
+      "default": []
+    },
+    "updateInternalDependencies": {
+      "enum": ["patch", "minor"],
+      "type": "string",
+      "description": "The minimum bump type to trigger automatic update of internal dependencies that are part of the same release.",
+      "default": "patch"
     }
   }
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -15,11 +15,7 @@ export let defaultWrittenConfig = {
   access: "restricted",
   baseBranch: "master",
   updateInternalDependencies: "patch",
-  ignore: [] as ReadonlyArray<string>,
-  ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-    onlyUpdatePeerDependentsWhenOutOfRange: false,
-    useCalculatedVersionForSnapshots: false
-  }
+  ignore: [] as ReadonlyArray<string>
 } as const;
 
 function getNormalisedChangelogOption(
@@ -267,9 +263,7 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
         json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH === undefined ||
         json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
           .onlyUpdatePeerDependentsWhenOutOfRange === undefined
-          ? defaultWrittenConfig
-              .___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
-              .onlyUpdatePeerDependentsWhenOutOfRange
+          ? false
           : json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
               .onlyUpdatePeerDependentsWhenOutOfRange,
 
@@ -277,9 +271,7 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
         json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH === undefined ||
         json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
           .useCalculatedVersionForSnapshots === undefined
-          ? defaultWrittenConfig
-              .___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
-              .useCalculatedVersionForSnapshots
+          ? false
           : json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
               .useCalculatedVersionForSnapshots
     }


### PR DESCRIPTION
This might need a prompt release because of the default written config including experimental flags right now.