### PR TITLE
Add support for `date` in changelogs

### DIFF
--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -34,7 +34,8 @@ export default async function generateMarkdown(
   }: {
     updateInternalDependencies: "patch" | "minor";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
-  }
+  },
+  date?: Date
 ) {
   if (release.type === "none") return null;
 
@@ -103,11 +104,25 @@ export default async function generateMarkdown(
   );
 
   return [
-    `## ${release.newVersion}`,
+    date
+      ? `## ${release.newVersion} - ${getDate(date)}`
+      : `## ${release.newVersion}`,
     await generateChangesForVersionTypeMarkdown(releaseObj, "major"),
     await generateChangesForVersionTypeMarkdown(releaseObj, "minor"),
     await generateChangesForVersionTypeMarkdown(releaseObj, "patch")
   ]
     .filter(line => line)
     .join("\n");
+}
+
+/**
+ * Get the release date
+ */
+function getDate(date: Date = new Date()) {
+  return `${date.getFullYear()}-${(date.getMonth() + 1)
+    .toString()
+    .padStart(2, "0")}-${date
+    .getDate()
+    .toString()
+    .padStart(2, "0")}`;
 }

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -40,7 +40,8 @@ export default async function applyReleasePlan(
   releasePlan: ReleasePlan,
   packages: Packages,
   config: Config = defaultConfig,
-  snapshot?: string | boolean
+  snapshot?: string | boolean,
+  date?: Date
 ) {
   let cwd = packages.root.dir;
 
@@ -71,7 +72,8 @@ export default async function applyReleasePlan(
     releaseWithPackages,
     changesets,
     config,
-    cwd
+    cwd,
+    date
   );
 
   if (releasePlan.preState !== undefined && snapshot === undefined) {
@@ -181,7 +183,8 @@ async function getNewChangelogEntry(
   releasesWithPackage: ModCompWithPackage[],
   changesets: NewChangeset[],
   config: Config,
-  cwd: string
+  cwd: string,
+  date?: Date
 ) {
   let getChangelogFuncs: ChangelogFunctions = {
     getReleaseLine: () => Promise.resolve(""),
@@ -227,7 +230,8 @@ async function getNewChangelogEntry(
           onlyUpdatePeerDependentsWhenOutOfRange:
             config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
               .onlyUpdatePeerDependentsWhenOutOfRange
-        }
+        },
+        date
       );
 
       return {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -147,6 +147,26 @@ We recommend making sure changes made from this commmand are merged back into ma
 
 This command will read then delete changesets on disk, ensuring that they are only used once.
 
+If you want your changelogs to include their creation date then add the `--date` flag.
+
+```
+changeset version --date
+```
+
+This will lead to a changelog looking like this.
+
+```md
+# pkg-a
+
+## 1.0.1 - 2020-06-30
+
+### Patch Changes
+
+- a very useful summary
+- Updated dependencies [undefined]
+  - pkg-b@1.0.1
+```
+
 ### publish
 
 ```

--- a/packages/cli/src/commands/version/index.ts
+++ b/packages/cli/src/commands/version/index.ts
@@ -10,6 +10,7 @@ import { getPackages } from "@manypkg/get-packages";
 import { removeEmptyFolders } from "../../utils/v1-legacy/removeFolders";
 import { readPreState } from "@changesets/pre";
 import { ExitError } from "@changesets/errors";
+import { CliOptions } from "../../types";
 
 let importantSeparator = chalk.red(
   "===============================IMPORTANT!==============================="
@@ -21,9 +22,7 @@ let importantEnd = chalk.red(
 
 export default async function version(
   cwd: string,
-  options: {
-    snapshot?: string | boolean;
-  },
+  options: Pick<CliOptions, "snapshot" | "date">,
   config: Config
 ) {
   let [_changesets, _preState] = await Promise.all([
@@ -77,7 +76,8 @@ export default async function version(
       ...config,
       commit: false
     },
-    options.snapshot
+    options.snapshot,
+    options.date ? new Date(Date.now()) : undefined
   );
 
   if (options.snapshot !== undefined && config.commit) {

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -80,7 +80,8 @@ export async function run(
       empty,
       ignore,
       snapshot,
-      tag
+      tag,
+      date
     }: CliOptions = flags;
     const deadFlags = ["updateChangelog", "isPublic", "skipCI", "commit"];
 
@@ -157,7 +158,7 @@ export async function run(
           throw new ExitError(1);
         }
 
-        await version(cwd, { snapshot }, config);
+        await version(cwd, { snapshot, date }, config);
         return;
       }
       case "publish": {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -13,6 +13,15 @@ export type CliOptions = {
   ignore?: string | string[];
   snapshot?: string | boolean;
   tag?: string;
+  /**
+   * When `true` the versioning command will include a date timestamp.
+   *
+   * The date is automatically set to the date the version command is being run
+   * at. See the link below for reasons on why this might be problematic.
+   *
+   * https://github.com/atlassian/changesets/issues/109#issuecomment-642491488
+   */
+  date?: boolean;
 };
 
 export type CommandOptions = CliOptions & {


### PR DESCRIPTION
## Description

Add support for dates in the changelog. 

## Usage

If you want your changelogs to include a creation date then add the `--date` flag.

```
changeset version --date
```

This will lead to a changelog like this.

```md
# pkg-a

## 1.0.1 - 2020-06-30

### Patch Changes

- a very useful summary
- Updated dependencies [undefined]
  - pkg-b@1.0.1
```

## Notes

This will be subject to the warnings mentioned by @Andarist in https://github.com/atlassian/changesets/issues/109#issuecomment-642491488.

Closes #109