### PR TITLE
Fixed return type of the `readPreState` function

### DIFF
--- a/.changeset/hungry-onions-flash.md
+++ b/.changeset/hungry-onions-flash.md
@@ -1,0 +1,5 @@
+---
+"@changesets/pre": patch
+---
+
+Fixed return type of the `readPreState` function. It is now properly annotated as `Promise<PreState | undefined>` instead of just `Promise<PreState>`.

--- a/packages/pre/src/index.ts
+++ b/packages/pre/src/index.ts
@@ -7,7 +7,7 @@ import {
   PreEnterButInPreModeError
 } from "@changesets/errors";
 
-export async function readPreState(cwd: string) {
+export async function readPreState(cwd: string): Promise<PreState | undefined> {
   let preStatePath = path.resolve(cwd, ".changeset", "pre.json");
   // TODO: verify that the pre state isn't broken
   let preState: PreState | undefined;


### PR DESCRIPTION
I'm not sure why this has to be explicitly annotated because local `preState` variable (which gets returned) is annotated as `PreState | undefined`, but somehow TS when generating types ignores `| undefined` part