### PR TITLE
Fix config override order

### DIFF
--- a/packages/cli/src/commands/version/index.ts
+++ b/packages/cli/src/commands/version/index.ts
@@ -74,8 +74,8 @@ export default async function version(
     releasePlan,
     packages,
     {
-      ...config,
-      commit: false
+      commit: false,
+      ...config
     },
     options.snapshot
   );


### PR DESCRIPTION
**Current behaviour:**
If the `commit` flag in config.json is set to `true` it is still overriden to `false` when doing `changeset version`

**Fix:**
Values in config.json will override the default value of `commit`