### PR TITLE
Remove packagesByNameWithVersionsFromBeforePreModeIfInPreMode and releasesFromUnfilteredChangesets

### DIFF
--- a/.changeset/gorgeous-weeks-begin.md
+++ b/.changeset/gorgeous-weeks-begin.md
@@ -1,0 +1,5 @@
+---
+"@changesets/assemble-release-plan": major
+---
+
+Returned releases in pre mode will have type of the highest bump type within the current release now, instead of having the highest bump type from among all changesets within this pre mode. So if you release a new prerelease including a major bump and later release the same package with a minor bump the assembled release will be of type minor - the final computed version will, of course, still be the next one for a major bump.


### PR DESCRIPTION
cc @mitchellhamilton 😱 

~it's super weird because I would totally expect for tests added here to fail: https://github.com/atlassian/changesets/pull/263 , need to investigate why they pass~ they pass because we've removed both of those variables and it's able to compute good new version based on the given information