### PR TITLE
Reorganize internals of @changesets/assemble-release-plan

### DIFF
--- a/packages/assemble-release-plan/src/types.ts
+++ b/packages/assemble-release-plan/src/types.ts
@@ -9,5 +9,5 @@ export type InternalRelease = {
 
 export type PreInfo = {
   state: PreState;
-  preVersions: Map<string, string>;
+  preVersions: Map<string, number>;
 };


### PR DESCRIPTION
This is just a small refactor of the internals - the core logic of `assembleReleasePlan` could be somewhat intimidating before, a good chunk of the code there has been dealing with pre state. The main change here just moves this to a separate function (a part of the related to pre mode code is also in `getRelevantChangesets` now).

This builds on top of https://github.com/atlassian/changesets/pull/454 so I've created a PR to that branch - it would be best to first merge the other one and then I will just rebase this on top of the master.