### PR TITLE
Revert "Respect casing of the existing changelog files (#406)"

### DIFF
--- a/.changeset/few-poets-compete.md
+++ b/.changeset/few-poets-compete.md
@@ -1,5 +1,0 @@
----
-"@changesets/apply-release-plan": minor
----
-
-Respect casing of the existing changelog files.


### PR DESCRIPTION
This reverts commit 66116ba4b3d87a49b1722ccbf7dcb4801672e579.

I don't think the change made in #406 is something that we want to do. Right now, if a repo is using changesets, you can make the assumption that changelogs are always at `CHANGELOG.md` which makes it easier to build tools(ofc this code isn't that complex but if someone was building a tool, they probably wouldn't think to do this) + using `CHANGELOG.md` is such a widespread name so there's no big reason to do this.