### PR TITLE
Add `doNotThank` option to `@changeset/changelog-github`

### DIFF
--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -40,12 +40,23 @@ const changelogFunctions: ChangelogFunctions = {
 
     return [changesetLink, ...updatedDepenenciesList].join("\n");
   },
-  getReleaseLine: async (changeset, type, options) => {
-    if (!options || !options.repo) {
+  getReleaseLine: async (changeset, type, options = {}) => {
+    if (!options.repo) {
       throw new Error(
         'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]'
       );
     }
+
+    const shouldThank = (user: string) => {
+      // Handle an array of names to not thank
+      if (Array.isArray(options.doNotThank)) {
+        return options.doNotThank.includes(user)
+      }
+      
+      // Should thank if it's null, true, anything except false
+      return options.doNotThank !== false
+    }
+
     const [firstLine, ...futureLines] = changeset.summary
       .split("\n")
       .map(l => l.trimRight());
@@ -56,9 +67,9 @@ const changelogFunctions: ChangelogFunctions = {
         commit: changeset.commit
       });
       return `\n\n- ${links.commit}${
-        links.pull === null ? "" : ` ${links.pull}`
+        links.pull == null ? "" : ` ${links.pull}`
       }${
-        links.user === null ? "" : ` Thanks ${links.user}!`
+        links.user == null && shouldThank(links.user) ? "" : ` Thanks ${links.user}!`
       } - ${firstLine}\n${futureLines.map(l => `  ${l}`).join("\n")}`;
     } else {
       return `\n\n- ${firstLine}\n${futureLines.map(l => `  ${l}`).join("\n")}`;


### PR DESCRIPTION
Takes a boolean (to disable thanking) or an array of names (to exclude them from being thanked).

Useful for if thanking people in the changelog is not necessary, e.g. thanking the main developer/maintainer over and over again, or in a private repo for work.

```
{
  "changelog": [
    "@changesets/changelog-github",
    {
      "repo": "org/repo",
      "doNotThank": true // Will not thank anyone
    }
  ],
}
```


```
{
  "changelog": [
    "@changesets/changelog-github",
    {
      "repo": "org/repo",
      "doNotThank": ["BeeeQueue"] // Will not thank BeeeQueue, but will thank anyone else (😢)
    }
  ],
}
```

---

_Was written directly on GitHub so might have style problems and has not been tested yet_

- [ ] Test locally