### PR TITLE
Add changeset for `@changesets/type` about exporting a new `Linked` type

### DIFF
--- a/.changeset/nine-swans-applaud.md
+++ b/.changeset/nine-swans-applaud.md
@@ -1,0 +1,5 @@
+---
+"@changesets/types": minor
+---
+
+Exported a new `Linked` type for convenience - it's an alias for `ReadonlyArray<ReadonlyArray<string>>`.`


### PR DESCRIPTION
This was missing in https://github.com/atlassian/changesets/pull/458