### PR TITLE
fix(cli): gracefully handle 403 errors when publishing

### DIFF
--- a/.changeset/clever-zebras-roll.md
+++ b/.changeset/clever-zebras-roll.md
@@ -1,0 +1,7 @@
+---
+"@changesets/cli": patch
+---
+
+Gracefully handle 403 errors when publishing.
+
+Sometimes NPM returns an error in case a version is already published, causing the publish script to fail and preventing changeset to finish the job. In this case, we should ignore the error.


### PR DESCRIPTION
Ref #478

This is a (naive) attempt to gracefully handle 403 errors.

Let me know if this is an acceptable approach or if we should go into another direction.