### PR TITLE
Automatically deepen clones to find correct commits

### DIFF
--- a/.changeset/six-roses-hammer.md
+++ b/.changeset/six-roses-hammer.md
@@ -1,0 +1,5 @@
+---
+"@changesets/git": minor
+---
+
+Automatically deepen shallow clones in order to determine the correct commit at which changelogs were found

--- a/.changeset/six-roses-hammer.md
+++ b/.changeset/six-roses-hammer.md
@@ -2,4 +2,9 @@
 "@changesets/git": minor
 ---
 
-Automatically deepen shallow clones in order to determine the correct commit at which changelogs were found
+Automatically deepen shallow clones in order to determine the correct commit at
+which changelogs were found.
+
+Deprecate the `getCommitThatAddsFile` function; it's replaced with
+a bulk `getCommitsThatAddFiles` operation which will safely deepen a
+shallow repo whilst processing multiple filenames simultaneously.

--- a/.changeset/six-roses-hammer.md
+++ b/.changeset/six-roses-hammer.md
@@ -2,9 +2,4 @@
 "@changesets/git": minor
 ---
 
-Automatically deepen shallow clones in order to determine the correct commit at
-which changelogs were found.
-
-Deprecate the `getCommitThatAddsFile` function; it's replaced with
-a bulk `getCommitsThatAddFiles` operation which will safely deepen a
-shallow repo whilst processing multiple filenames simultaneously.
+Automatically deepen shallow clones in order to determine the correct commit at which changesets were added.

--- a/.changeset/some-other-changeset.md
+++ b/.changeset/some-other-changeset.md
@@ -1,0 +1,6 @@
+---
+"@changesets/git": minor
+---
+
+Deprecate the `getCommitThatAddsFile` function. It's replaced with a bulk `getCommitsThatAddFiles` operation which will safely deepen a
+shallow repo whilst processing multiple filenames simultaneously.

--- a/.changeset/yet-another-core-changeset.md
+++ b/.changeset/yet-another-core-changeset.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+Automatically deepen shallow clones in order to determine the correct commit at which changesets were added. This helps Git-based changelog generators to always link to the correct commit. From now on it's not required to configure `fetch-depth: 0` for your `actions/checkout` when using [Changesets GitHub action](https://github.com/changesets/action).

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -47,6 +47,8 @@ git.add.mockImplementation(() => Promise.resolve(true));
 // @ts-ignore
 git.commit.mockImplementation(() => Promise.resolve(true));
 // @ts-ignore
+git.getCommitsThatAddFiles.mockImplementation(() => Promise.resolve([]));
+// @ts-ignore
 git.tag.mockImplementation(() => Promise.resolve(true));
 
 const simpleChangeset: NewChangeset = {

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -15,6 +15,7 @@
     "spawndamnit": "^2.0.0"
   },
   "devDependencies": {
+    "file-url": "^3.0.0",
     "fixturez": "^1.1.0"
   }
 }

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -101,6 +101,7 @@ async function getCommitsThatAddFiles(
     if (await isRepoShallow()) {
       // Yes.
       await deepenCloneBy(50);
+      remaining = commitsWithMissingParents.map(p => p.path);
     } else {
       // It's not a shallow clone, so all the commit SHAs we have are legitimate.
       for (const unresolved of commitsWithMissingParents) {
@@ -108,8 +109,6 @@ async function getCommitsThatAddFiles(
       }
       break;
     }
-
-    remaining = commitsWithMissingParents.map(p => p.path);
   } while (true);
 
   return gitPaths.map(p => map.get(p));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3422,6 +3422,11 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
+file-url@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/file-url/-/file-url-3.0.0.tgz#247a586a746ce9f7a8ed05560290968afc262a77"
+  integrity sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA==
+
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"


### PR DESCRIPTION
This fixes #494 - where we would get the wrong commit
that added a file if we were operating in a shallow
repository that didn't contain the actual commit -
by modifying `getCommitThatAddsFile` so that it
automatically deepens a shallow clone until it finds the
_real_ commit that added a file.