### PR TITLE
Dont fail `changeset status` command if there are no changed packages

### DIFF
--- a/.changeset/chatty-plums-watch.md
+++ b/.changeset/chatty-plums-watch.md
@@ -2,4 +2,4 @@
 "@changesets/cli": minor
 ---
 
-`changeset status` command no longer errors when no publishable packages have been changed.
+`changeset status` command no longer errors when no packages have been changed.

--- a/.changeset/chatty-plums-watch.md
+++ b/.changeset/chatty-plums-watch.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+`changeset status` command no longer errors when no publishable packages have been changed.

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -218,7 +218,6 @@ export default async function createChangeset(
       )}? (current version is ${pkg.packageJson.version})`,
       ["patch", "minor", "major"]
     );
-    console.log(type);
     if (type === "major") {
       let shouldReleaseAsMajor = await confirmMajorRelease(pkg.packageJson);
       if (!shouldReleaseAsMajor) {

--- a/packages/cli/src/commands/publish/__tests__/index.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/index.test.ts
@@ -4,6 +4,7 @@ import { defaultConfig } from "@changesets/config";
 import * as path from "path";
 import * as pre from "@changesets/pre";
 import { Config } from "@changesets/types";
+import { temporarilySilenceLogs } from "@changesets/test-utils";
 
 let changelogPath = path.resolve(__dirname, "../../changelog");
 let modifiedDefaultConfig: Config = {
@@ -18,6 +19,7 @@ jest.mock("../publishPackages.ts");
 jest.mock("@changesets/pre");
 
 describe("Publish command", () => {
+  temporarilySilenceLogs();
   let cwd: string;
 
   beforeEach(async () => {

--- a/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publishPackages.test.ts
@@ -3,6 +3,7 @@ import fixtures from "fixturez";
 import publishPackages from "../publishPackages";
 import * as npmUtils from "../npm-utils";
 import { getPackages } from "@manypkg/get-packages";
+import { temporarilySilenceLogs } from "@changesets/test-utils";
 
 jest.mock("../npm-utils");
 jest.mock("is-ci", () => true);
@@ -10,6 +11,7 @@ jest.mock("is-ci", () => true);
 const f = fixtures(__dirname);
 
 describe("publishPackages", () => {
+  temporarilySilenceLogs();
   let cwd: string;
 
   beforeEach(async () => {

--- a/packages/cli/src/commands/status/__tests__/status.ts
+++ b/packages/cli/src/commands/status/__tests__/status.ts
@@ -76,8 +76,6 @@ describe("status", () => {
   let cwd: string;
 
   beforeEach(async () => {
-    // @ts-ignore
-    jest.spyOn(process, "exit").mockImplementation(() => {});
     cwd = await f.copy("simple-project");
   });
 
@@ -97,6 +95,8 @@ describe("status", () => {
 
   it("should exit early with a non-zero error code when there are changed packages but no changesets", async () => {
     // @ts-ignore
+    jest.spyOn(process, "exit").mockImplementation(() => {});
+    // @ts-ignore
     git.getChangedPackagesSinceRef.mockImplementation(
       () => simpleChangedPackagesList
     );
@@ -107,6 +107,8 @@ describe("status", () => {
   });
 
   it("should not exit early with a non-zero error code when there are no changed packages", async () => {
+    // @ts-ignore
+    jest.spyOn(process, "exit").mockImplementation(() => {});
     // @ts-ignore
     git.getChangedPackagesSinceRef.mockImplementation(() => []);
 
@@ -121,6 +123,8 @@ describe("status", () => {
   });
 
   it("should not exit early with a non-zero code when there are changed packages and also a changeset", async () => {
+    // @ts-ignore
+    jest.spyOn(process, "exit").mockImplementation(() => {});
     // @ts-ignore
     git.getChangedPackagesSinceRef.mockImplementation(
       () => simpleChangedPackagesList

--- a/packages/cli/src/commands/status/__tests__/status.ts
+++ b/packages/cli/src/commands/status/__tests__/status.ts
@@ -66,6 +66,8 @@ describe("status", () => {
   beforeEach(async () => {
     // @ts-ignore
     git.getChangedPackagesSinceRef.mockImplementation(() => []);
+    // @ts-ignore
+    jest.spyOn(process, "exit").mockImplementation(() => {});
     cwd = await f.copy("simple-project");
   });
 
@@ -81,8 +83,6 @@ describe("status", () => {
 
   it("should exit early with a non-zero error code when there are changed packages but no changesets", async () => {
     // @ts-ignore
-    const mockExit = jest.spyOn(process, "exit").mockImplementation(() => {});
-    // @ts-ignore
     git.getChangedPackagesSinceRef.mockImplementation(() => [
       {
         name: "pkg-a",
@@ -92,16 +92,13 @@ describe("status", () => {
 
     await status(cwd, {}, defaultConfig);
 
-    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it("should not exit early with a non-zero error code when there are no changed packages", async () => {
-    // @ts-ignore
-    const mockExit = jest.spyOn(process, "exit").mockImplementation(() => {});
-
     const releaseObj = await status(cwd, {}, defaultConfig);
 
-    expect(mockExit).not.toHaveBeenCalled();
+    expect(process.exit).not.toHaveBeenCalled();
     expect(releaseObj).toEqual({
       changesets: [],
       releases: [],
@@ -110,8 +107,6 @@ describe("status", () => {
   });
 
   it("should not exit early with a non-zero code when there are changed packages and also a changeset", async () => {
-    // @ts-ignore
-    const mockExit = jest.spyOn(process, "exit").mockImplementation(() => {});
     // @ts-ignore
     git.getChangedPackagesSinceRef.mockImplementation(() => [
       {
@@ -127,7 +122,7 @@ describe("status", () => {
     const releaseObj = await status(cwd, {}, defaultConfig);
 
     expect(releaseObj).toEqual(simpleReleasePlan);
-    expect(mockExit).not.toHaveBeenCalled();
+    expect(process.exit).not.toHaveBeenCalled();
   });
 
   it.skip("should respect since master flag", () => false);


### PR DESCRIPTION
Fixes #496.

Add a check to the status command, so `process.exit(1)` is only called if there are no changesets _and_ a package has been changed. This prevents a few false-positives that can hurt DX. See #496 for more details.

@Andarist I wasn't sure if you wanted this to be a major bump or not.. IMO this should be a minor bump, since the new version will produce _less_ errors than before, not more (meaning, no CI checks should fail that were not already failing before). Let me know if you agree or not, and I'll add the changeset accordingly.