### PR TITLE
fix: don't reopen an editor that is saved without summary

### DIFF
--- a/.changeset/happy-goats-remember.md
+++ b/.changeset/happy-goats-remember.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": patch
+---
+
+If an editor is saved with no summary, don't reopen it.

--- a/.changeset/happy-goats-remember.md
+++ b/.changeset/happy-goats-remember.md
@@ -2,4 +2,4 @@
 "@changesets/cli": patch
 ---
 
-If an editor is saved with no summary, don't reopen it.
+From now on, to fix issues with some auto-save configurations in IDEs, the editor won't be re-opened if one saves an empty summary. In such a scenario the CLI will prompt again for the summary to be written in the terminal.

--- a/packages/cli/src/commands/add/__tests__/add.ts
+++ b/packages/cli/src/commands/add/__tests__/add.ts
@@ -105,11 +105,11 @@ describe("Changesets", () => {
   });
 
   it.each`
-    consoleSummaries               | editorSummaries                           | expectedSummary
-    ${["summary on step 1"]}       | ${[]}                                     | ${"summary on step 1"}
-    ${[""]}                        | ${["summary in external editor"]}         | ${"summary in external editor"}
-    ${[""]}                        | ${["", "", "summary in external editor"]} | ${"summary in external editor"}
-    ${["", "summary after error"]} | ${1 /* mock implementation will throw */} | ${"summary after error"}
+    consoleSummaries                          | editorSummaries                           | expectedSummary
+    ${["summary on step 1"]}                  | ${[]}                                     | ${"summary on step 1"}
+    ${[""]}                                   | ${["summary in external editor"]}         | ${"summary in external editor"}
+    ${["", "summary after editor cancelled"]} | ${[""]}                                   | ${"summary after editor cancelled"}
+    ${["", "summary after error"]}            | ${1 /* mock implementation will throw */} | ${"summary after error"}
   `(
     "should read summary",
     // @ts-ignore

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -232,17 +232,23 @@ export default async function createChangeset(
   );
 
   let summary = await cli.askQuestion("Summary");
-  if (summary.length === 0) summary = cli.askQuestionWithEditor("");
-  try {
-    while (summary.length === 0) {
-      summary = await cli.askQuestionWithEditor(
-        "\n\n# A summary is required for the changelog! 😪"
+  if (summary.length === 0) {
+    try {
+      summary = cli.askQuestionWithEditor(
+        "\n\n# Please enter a summary for your changes.\n# An empty message aborts the editor."
+      );
+      if (summary.length > 0) {
+        return {
+          summary,
+          releases
+        };
+      }
+    } catch (err) {
+      log(
+        "An error happened using external editor. Please type your summary here:"
       );
     }
-  } catch (err) {
-    log(
-      "An error happened using external editor. Please type your summary here:"
-    );
+
     summary = await cli.askQuestion("");
     while (summary.length === 0) {
       summary = await cli.askQuestion(


### PR DESCRIPTION
close #445