### PR TITLE
Allow replacing the PR/commit/author shown in the changlog line by writing `pr: some-pr-number` and etc.

### DIFF
--- a/.changeset/olive-hotels-hear.md
+++ b/.changeset/olive-hotels-hear.md
@@ -2,4 +2,4 @@
 "@changesets/changelog-github": minor
 ---
 
-Allow replacing the PR/commit/author shown in the changlog line by writing `pr: some-pr-number` and similarly for `commit` and `author`.
+Allow replacing the PR/commit/author shown in the changlog line by writing `pr: some-pr-number` and similarly for `commit` and `author` in the changlog summary(not the frontmatter).

--- a/.changeset/olive-hotels-hear.md
+++ b/.changeset/olive-hotels-hear.md
@@ -1,0 +1,5 @@
+---
+"@changesets/changelog-github": minor
+---
+
+Allow replacing the PR/commit/author shown in the changlog line by writing `pr: some-pr-number` and similarly for `commit` and `author`.

--- a/.changeset/tidy-tools-applaud.md
+++ b/.changeset/tidy-tools-applaud.md
@@ -1,0 +1,5 @@
+---
+"@changesets/get-github-info": minor
+---
+
+Added `getInfoFromPullRequest`

--- a/packages/changelog-github/package.json
+++ b/packages/changelog-github/package.json
@@ -12,6 +12,6 @@
     "dotenv": "^8.1.0"
   },
   "devDependencies": {
-    "@changesets/parse": "^0.3.7"
+    "@changesets/parse": "*"
   }
 }

--- a/packages/changelog-github/package.json
+++ b/packages/changelog-github/package.json
@@ -10,5 +10,8 @@
     "@changesets/get-github-info": "^0.4.5",
     "@changesets/types": "^3.0.0",
     "dotenv": "^8.1.0"
+  },
+  "devDependencies": {
+    "@changesets/parse": "^0.3.7"
   }
 }

--- a/packages/changelog-github/src/index.test.ts
+++ b/packages/changelog-github/src/index.test.ts
@@ -1,0 +1,101 @@
+import changelogFunctions from "./index";
+import parse from "@changesets/parse";
+
+const getReleaseLine = changelogFunctions.getReleaseLine;
+
+const data = {
+  commit: "a085003",
+  user: "Andarist",
+  pull: 1613,
+  repo: "emotion-js/emotion"
+};
+
+jest.mock(
+  "@changesets/get-github-info",
+  (): typeof import("@changesets/get-github-info") => {
+    // this is duplicated because jest.mock reordering things
+    const data = {
+      commit: "a085003",
+      user: "Andarist",
+      pull: 1613,
+      repo: "emotion-js/emotion"
+    };
+    const links = {
+      user: `[@${data.user}](https://github.com/${data.user})`,
+      pull: `[#${data.pull}](https://github.com/${data.repo}/pull/${data.pull})`,
+      commit: `[\`${data.commit}\`](https://github.com/${data.repo}/commit/${data.commit})`
+    };
+    return {
+      async getInfo({ commit, repo }) {
+        expect(commit).toBe(data.commit);
+        expect(repo).toBe(data.repo);
+        return {
+          pull: data.pull,
+          user: data.user,
+          links
+        };
+      },
+      async getInfoFromPullRequest({ pull, repo }) {
+        expect(pull).toBe(data.pull);
+        expect(repo).toBe(data.repo);
+        return {
+          commit: data.commit,
+          user: data.user,
+          links
+        };
+      }
+    };
+  }
+);
+const expected = `\n\n- [#1613](https://github.com/emotion-js/emotion/pull/1613) [\`a085003\`](https://github.com/emotion-js/emotion/commit/a085003) Thanks [@Andarist](https://github.com/Andarist)! - something\n`;
+
+describe.each([data.commit, "wrongcommit", undefined])(
+  "with commit from changeset of %s",
+  commitFromChangeset => {
+    const getChangeset = (content: string) => {
+      return [
+        {
+          ...parse(
+            `---
+      pkg: "minor"
+      ---
+      
+      something
+      ${content}
+      `
+          ),
+          id: "some-id",
+          commit: commitFromChangeset
+        },
+        "minor",
+        { repo: data.repo }
+      ] as const;
+    };
+
+    test.each(["pr", "pull request", "pull"])(
+      "override pr with %s keyword",
+      async keyword => {
+        expect(
+          await getReleaseLine(...getChangeset(`${keyword}: ${data.pull}`))
+        ).toEqual(expected);
+      }
+    );
+    if (commitFromChangeset === "a085003") {
+      test.each(["author", "user"])(
+        "override author with %s keyword",
+        async keyword => {
+          const expected = `\n\n- [#1613](https://github.com/emotion-js/emotion/pull/1613) [\`a085003\`](https://github.com/emotion-js/emotion/commit/a085003) Thanks [@other](https://github.com/other)! - something\n`;
+
+          expect(
+            await getReleaseLine(...getChangeset(`${keyword}: other`))
+          ).toEqual(expected);
+        }
+      );
+    }
+    test("override commit with commit keyword", async () => {
+      expect(
+        await getReleaseLine(...getChangeset(`commit: ${data.commit}`))
+      ).toEqual(expected);
+    });
+  }
+);

--- a/packages/changelog-github/src/index.test.ts
+++ b/packages/changelog-github/src/index.test.ts
@@ -71,16 +71,21 @@ const data = {
 describe.each([data.commit, "wrongcommit", undefined])(
   "with commit from changeset of %s",
   commitFromChangeset => {
-    test.each(["pr", "pull request", "pull"])(
+    describe.each(["pr", "pull request", "pull"])(
       "override pr with %s keyword",
-      async keyword => {
-        expect(
-          await getReleaseLine(
-            ...getChangeset(`${keyword}: ${data.pull}`, commitFromChangeset)
-          )
-        ).toEqual(
-          `\n\n- [#1613](https://github.com/emotion-js/emotion/pull/1613) [\`a085003\`](https://github.com/emotion-js/emotion/commit/a085003) Thanks [@Andarist](https://github.com/Andarist)! - something\n`
-        );
+      keyword => {
+        test.each(["with #", "without #"] as const)("%s", async kind => {
+          expect(
+            await getReleaseLine(
+              ...getChangeset(
+                `${keyword}: ${kind === "with #" ? "#" : ""}${data.pull}`,
+                commitFromChangeset
+              )
+            )
+          ).toEqual(
+            `\n\n- [#1613](https://github.com/emotion-js/emotion/pull/1613) [\`a085003\`](https://github.com/emotion-js/emotion/commit/a085003) Thanks [@Andarist](https://github.com/Andarist)! - something\n`
+          );
+        });
       }
     );
     test("override commit with commit keyword", async () => {
@@ -95,13 +100,20 @@ describe.each([data.commit, "wrongcommit", undefined])(
   }
 );
 
-test.each(["author", "user"])(
+describe.each(["author", "user"])(
   "override author with %s keyword",
-  async keyword => {
-    expect(
-      await getReleaseLine(...getChangeset(`${keyword}: other`, data.commit))
-    ).toEqual(
-      `\n\n- [#1613](https://github.com/emotion-js/emotion/pull/1613) [\`a085003\`](https://github.com/emotion-js/emotion/commit/a085003) Thanks [@other](https://github.com/other)! - something\n`
-    );
+  keyword => {
+    test.each(["with @", "without @"] as const)("%s", async kind => {
+      expect(
+        await getReleaseLine(
+          ...getChangeset(
+            `${keyword}: ${kind === "with @" ? "@" : ""}other`,
+            data.commit
+          )
+        )
+      ).toEqual(
+        `\n\n- [#1613](https://github.com/emotion-js/emotion/pull/1613) [\`a085003\`](https://github.com/emotion-js/emotion/commit/a085003) Thanks [@other](https://github.com/other)! - something\n`
+      );
+    });
   }
 );

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -49,7 +49,7 @@ const changelogFunctions: ChangelogFunctions = {
 
     let prFromSummary: number | undefined;
     let commitFromSummary: string | undefined;
-    let userFromSummaryOverride: string | undefined;
+    let userFromSummary: string | undefined;
 
     const replacedChangelog = changeset.summary
       .replace(/(?:pr|pull|pull\s+request):\s*#?(\d+)/i, (_, pr) => {
@@ -62,7 +62,7 @@ const changelogFunctions: ChangelogFunctions = {
         return "";
       })
       .replace(/(?:author|user):\s*@?([^\s]+)/i, (_, user) => {
-        userFromSummaryOverride = `[@${user}](https://github.com/${user})`;
+        userFromSummary = user;
         return "";
       })
       .trim();
@@ -100,7 +100,9 @@ const changelogFunctions: ChangelogFunctions = {
       };
     })();
 
-    const user = userFromSummaryOverride || links.user;
+    const user = userFromSummary
+      ? `[@${userFromSummary}](https://github.com/${userFromSummary})`
+      : links.user;
 
     const prefix = [
       links.pull === null ? "" : ` ${links.pull}`,

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -1,7 +1,7 @@
 import { ChangelogFunctions } from "@changesets/types";
 // @ts-ignore
 import { config } from "dotenv";
-import { getInfo } from "@changesets/get-github-info";
+import { getInfo, getInfoFromPullRequest } from "@changesets/get-github-info";
 
 config();
 
@@ -46,23 +46,71 @@ const changelogFunctions: ChangelogFunctions = {
         'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]'
       );
     }
-    const [firstLine, ...futureLines] = changeset.summary
+
+    let prFromSummary: number | undefined;
+    let commitFromSummary: string | undefined;
+    let userFromSummaryOverride: string | undefined;
+
+    const replacedChangelog = changeset.summary
+      .replace(/(?:pr|pull|pull\s+request):\s*#?(\d+)/i, (_, pr) => {
+        let num = Number(pr);
+        if (!isNaN(num)) prFromSummary = num;
+        return "";
+      })
+      .replace(/commit:\s*([^\s]+)/i, (_, commit) => {
+        commitFromSummary = commit;
+        return "";
+      })
+      .replace(/(?:author|user):\s*@?([^\s]+)/i, (_, user) => {
+        userFromSummaryOverride = `[@${user}](https://github.com/${user})`;
+        return "";
+      })
+      .trim();
+
+    const [firstLine, ...futureLines] = replacedChangelog
       .split("\n")
       .map(l => l.trimRight());
 
-    if (changeset.commit) {
-      let { links } = await getInfo({
-        repo: options.repo,
-        commit: changeset.commit
-      });
-      return `\n\n- ${links.commit}${
-        links.pull === null ? "" : ` ${links.pull}`
-      }${
-        links.user === null ? "" : ` Thanks ${links.user}!`
-      } - ${firstLine}\n${futureLines.map(l => `  ${l}`).join("\n")}`;
-    } else {
-      return `\n\n- ${firstLine}\n${futureLines.map(l => `  ${l}`).join("\n")}`;
-    }
+    const links = await (async () => {
+      if (prFromSummary !== undefined) {
+        let { links } = await getInfoFromPullRequest({
+          repo: options.repo,
+          pull: prFromSummary
+        });
+        if (commitFromSummary) {
+          links = {
+            ...links,
+            commit: `[\`${commitFromSummary}\`](https://github.com/${options.repo}/commit/${commitFromSummary})`
+          };
+        }
+        return links;
+      }
+      const commitToFetchFrom = commitFromSummary || changeset.commit;
+      if (commitToFetchFrom) {
+        let { links } = await getInfo({
+          repo: options.repo,
+          commit: commitToFetchFrom
+        });
+        return links;
+      }
+      return {
+        commit: null,
+        pull: null,
+        user: null
+      };
+    })();
+
+    const user = userFromSummaryOverride || links.user;
+
+    const prefix = [
+      links.pull === null ? "" : ` ${links.pull}`,
+      links.commit === null ? "" : ` ${links.commit}`,
+      user === null ? "" : ` Thanks ${user}!`
+    ].join("");
+
+    return `\n\n-${prefix ? `${prefix} -` : ""} ${firstLine}\n${futureLines
+      .map(l => `  ${l}`)
+      .join("\n")}`;
   }
 };
 

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -52,16 +52,16 @@ const changelogFunctions: ChangelogFunctions = {
     let userFromSummary: string | undefined;
 
     const replacedChangelog = changeset.summary
-      .replace(/\n\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/i, (_, pr) => {
+      .replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
         let num = Number(pr);
         if (!isNaN(num)) prFromSummary = num;
         return "";
       })
-      .replace(/\n\s*commit:\s*([^\s]+)/i, (_, commit) => {
+      .replace(/^\s*commit:\s*([^\s]+)/im, (_, commit) => {
         commitFromSummary = commit;
         return "";
       })
-      .replace(/\n\s*(?:author|user):\s*@?([^\s]+)/i, (_, user) => {
+      .replace(/^\s*(?:author|user):\s*@?([^\s]+)/im, (_, user) => {
         userFromSummary = user;
         return "";
       })

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -52,16 +52,16 @@ const changelogFunctions: ChangelogFunctions = {
     let userFromSummary: string | undefined;
 
     const replacedChangelog = changeset.summary
-      .replace(/(?:pr|pull|pull\s+request):\s*#?(\d+)/i, (_, pr) => {
+      .replace(/\n\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/i, (_, pr) => {
         let num = Number(pr);
         if (!isNaN(num)) prFromSummary = num;
         return "";
       })
-      .replace(/commit:\s*([^\s]+)/i, (_, commit) => {
+      .replace(/\n\s*commit:\s*([^\s]+)/i, (_, commit) => {
         commitFromSummary = commit;
         return "";
       })
-      .replace(/(?:author|user):\s*@?([^\s]+)/i, (_, user) => {
+      .replace(/\n\s*(?:author|user):\s*@?([^\s]+)/i, (_, user) => {
         userFromSummary = user;
         return "";
       })

--- a/packages/get-github-info/src/index.ts
+++ b/packages/get-github-info/src/index.ts
@@ -120,6 +120,8 @@ const GHDataLoader = new DataLoader(async (requests: RequestData[]) => {
     };
     cleanedData[repo] = output;
     Object.entries(data.data[`a${index}`]).forEach(([field, value]) => {
+      // this is "a" because that's how it was when it was first written, "a" means it's a commit not a pr
+      // we could change it to commit__ but then we have to get new GraphQL results from the GH API to put in the tests
       if (field[0] === "a") {
         output.commit[field.substring(1)] = value;
       } else {

--- a/packages/get-github-info/src/index.ts
+++ b/packages/get-github-info/src/index.ts
@@ -218,7 +218,7 @@ export async function getInfoFromPullRequest(request: {
   };
 }> {
   if (request.pull === undefined) {
-    throw new Error("Please pass a commit SHA to getInfo");
+    throw new Error("Please pass a pull request number");
   }
 
   if (!request.repo) {

--- a/packages/get-github-info/src/index.ts
+++ b/packages/get-github-info/src/index.ts
@@ -4,12 +4,16 @@ import DataLoader from "dataloader";
 
 const validRepoNameRegex = /^[\w.-]+\/[\w.-]+$/;
 
-type RequestData = {
-  commit: string;
-  repo: string;
-};
+type RequestData =
+  | { kind: "commit"; repo: string; commit: string }
+  | { kind: "pull"; repo: string; pull: number };
 
-function makeQuery(repos: any) {
+type ReposWithCommitsAndPRsToFetch = Record<
+  string,
+  ({ kind: "commit"; commit: string } | { kind: "pull"; pull: number })[]
+>;
+
+function makeQuery(repos: ReposWithCommitsAndPRsToFetch) {
   return `
       query {
         ${Object.keys(repos)
@@ -20,12 +24,11 @@ function makeQuery(repos: any) {
             name: ${JSON.stringify(repo.split("/")[1])}
           ) {
             ${repos[repo]
-              .map(
-                (
-                  commit: string
-                ) => `a${commit}: object(expression: ${JSON.stringify(
-                  commit
-                )}) {
+              .map(data =>
+                data.kind === "commit"
+                  ? `a${data.commit}: object(expression: ${JSON.stringify(
+                      data.commit
+                    )}) {
             ... on Commit {
             commitUrl
             associatedPullRequests(first: 50) {
@@ -46,6 +49,17 @@ function makeQuery(repos: any) {
               }
             }
           }}`
+                  : `pr__${data.pull}: pullRequest(number: ${data.pull}) {
+                    url
+                    author {
+                      login
+                      url
+                    }
+                    mergeCommit {
+                      commitUrl
+                      abbreviatedOid
+                    }            
+                  }`
               )
               .join("\n")}
           }`
@@ -70,12 +84,12 @@ const GHDataLoader = new DataLoader(async (requests: RequestData[]) => {
       "Please create a GitHub personal access token at https://github.com/settings/tokens/new and add it as the GITHUB_TOKEN environment variable"
     );
   }
-  let repos: Record<RequestData["repo"], Array<RequestData["commit"]>> = {};
-  requests.forEach(({ commit, repo }) => {
+  let repos: ReposWithCommitsAndPRsToFetch = {};
+  requests.forEach(({ repo, ...data }) => {
     if (repos[repo] === undefined) {
       repos[repo] = [];
     }
-    repos[repo].push(commit);
+    repos[repo].push(data);
   });
 
   const data = await fetch("https://api.github.com/graphql", {
@@ -95,22 +109,37 @@ const GHDataLoader = new DataLoader(async (requests: RequestData[]) => {
     );
   }
 
-  let cleanedData: Record<any, any> = {};
-  let dataKeys = Object.keys(data.data);
+  let cleanedData: Record<
+    string,
+    { commit: Record<string, any>; pull: Record<string, any> }
+  > = {};
   Object.keys(repos).forEach((repo, index) => {
-    cleanedData[repo] = {};
-    for (let nearlyCommit in data.data[dataKeys[index]]) {
-      cleanedData[repo][nearlyCommit.substring(1)] =
-        data.data[dataKeys[index]][nearlyCommit];
-    }
+    let output: { commit: Record<string, any>; pull: Record<string, any> } = {
+      commit: {},
+      pull: {}
+    };
+    cleanedData[repo] = output;
+    Object.entries(data.data[`a${index}`]).forEach(([field, value]) => {
+      if (field[0] === "a") {
+        output.commit[field.substring(1)] = value;
+      } else {
+        output.pull[field.replace("pr__", "")] = value;
+      }
+    });
   });
 
-  return requests.map(({ repo, commit }) => cleanedData[repo][commit]);
+  return requests.map(
+    ({ repo, ...data }) =>
+      cleanedData[repo][data.kind][
+        data.kind === "pull" ? data.pull : data.commit
+      ]
+  );
 });
 
-export async function getInfo(
-  request: RequestData
-): Promise<{
+export async function getInfo(request: {
+  commit: string;
+  repo: string;
+}): Promise<{
   user: string | null;
   pull: number | null;
   links: {
@@ -135,7 +164,7 @@ export async function getInfo(
     );
   }
 
-  const data = await GHDataLoader.load(request);
+  const data = await GHDataLoader.load({ kind: "commit", ...request });
   let user = null;
   if (data.author && data.author.user) {
     user = data.author.user;
@@ -171,6 +200,52 @@ export async function getInfo(
       pull: associatedPullRequest
         ? `[#${associatedPullRequest.number}](${associatedPullRequest.url})`
         : null,
+      user: user ? `[@${user.login}](${user.url})` : null
+    }
+  };
+}
+
+export async function getInfoFromPullRequest(request: {
+  pull: number;
+  repo: string;
+}): Promise<{
+  user: string | null;
+  commit: string | null;
+  links: {
+    commit: string | null;
+    pull: string;
+    user: string | null;
+  };
+}> {
+  if (request.pull === undefined) {
+    throw new Error("Please pass a commit SHA to getInfo");
+  }
+
+  if (!request.repo) {
+    throw new Error(
+      "Please pass a GitHub repository in the form of userOrOrg/repoName to getInfo"
+    );
+  }
+
+  if (!validRepoNameRegex.test(request.repo)) {
+    throw new Error(
+      `Please pass a valid GitHub repository in the form of userOrOrg/repoName to getInfo (it has to match the "${validRepoNameRegex.source}" pattern)`
+    );
+  }
+
+  const data = await GHDataLoader.load({ kind: "pull", ...request });
+  let user = data?.author;
+
+  let commit = data?.mergeCommit;
+
+  return {
+    user: user ? user.login : null,
+    commit: commit ? commit.abbreviatedOid : null,
+    links: {
+      commit: commit
+        ? `[\`${commit.abbreviatedOid}\`](${commit.commitUrl})`
+        : null,
+      pull: `[#${request.pull}](https://github.com/${request.repo}/pull/${request.pull})`,
       user: user ? `[@${user.login}](${user.url})` : null
     }
   };


### PR DESCRIPTION
An idea I had to solve the "oh no, I just merged a PR without a changeset and now that I add one, it'll attribute it to the wrong PR" problem.