### PR TITLE
feat: enable output of global changelog

### DIFF
--- a/packages/apply-release-plan/src/get-changelog-entry.ts
+++ b/packages/apply-release-plan/src/get-changelog-entry.ts
@@ -2,6 +2,7 @@ import { ChangelogFunctions, NewChangesetWithCommit } from "@changesets/types";
 
 import { ModCompWithPackage } from "@changesets/types";
 import startCase from "lodash.startcase";
+import { ChangelogEntry } from "./types";
 import { shouldUpdateDependencyBasedOnConfig } from "./utils";
 
 type ChangelogLines = {
@@ -35,7 +36,7 @@ export default async function generateMarkdown(
     updateInternalDependencies: "patch" | "minor";
     onlyUpdatePeerDependentsWhenOutOfRange: boolean;
   }
-) {
+): Promise<ChangelogEntry | null> {
   if (release.type === "none") return null;
 
   const releaseObj: ChangelogLines = {
@@ -102,12 +103,22 @@ export default async function generateMarkdown(
     )
   );
 
-  return [
-    `## ${release.newVersion}`,
-    await generateChangesForVersionTypeMarkdown(releaseObj, "major"),
-    await generateChangesForVersionTypeMarkdown(releaseObj, "minor"),
-    await generateChangesForVersionTypeMarkdown(releaseObj, "patch")
-  ]
-    .filter(line => line)
-    .join("\n");
+  const title = `## ${release.newVersion}`;
+  const major = await generateChangesForVersionTypeMarkdown(
+    releaseObj,
+    "major"
+  );
+  const minor = await generateChangesForVersionTypeMarkdown(
+    releaseObj,
+    "minor"
+  );
+  const patch = await generateChangesForVersionTypeMarkdown(
+    releaseObj,
+    "patch"
+  );
+
+  return {
+    title,
+    body: [major, minor, patch].filter(line => line).join("\n")
+  };
 }

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -63,7 +63,7 @@ export default async function applyReleasePlan(
   config: Config = defaultConfig,
   options: {
     snapshot?: string | boolean;
-    output?: boolean;
+    globalChangelog?: boolean;
   } = {}
 ) {
   let cwd = packages.root.dir;
@@ -180,7 +180,7 @@ export default async function applyReleasePlan(
     );
   }
 
-  if (options.output) {
+  if (options.globalChangelog) {
     let output = "";
 
     for (let release of finalisedRelease) {

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -136,9 +136,14 @@ export default async function applyReleasePlan(
     await updatePackageJson(pkgJSONPath, packageJson);
     touchedFiles.push(pkgJSONPath);
 
-    if (changelog && changelog.length > 0) {
+    if (changelog && changelog.body.length > 0) {
       const changelogPath = path.resolve(dir, "CHANGELOG.md");
-      await updateChangelog(changelogPath, changelog, name, prettierConfig);
+      await updateChangelog(
+        changelogPath,
+        `${changelog.title}\n${changelog.body}`,
+        name,
+        prettierConfig
+      );
       touchedFiles.push(changelogPath);
     }
   }
@@ -180,15 +185,15 @@ export default async function applyReleasePlan(
 
     for (let release of finalisedRelease) {
       const { changelog, name, newVersion } = release;
-      console.log("changelog", name, changelog);
-      if (changelog && changelog.length > 0) {
-        output += `# ${name}@${newVersion}\n\n${changelog}\n`;
+      if (changelog && changelog.body.length > 0) {
+        output += `## ${name}@${newVersion}\n\n${changelog.body}\n`;
       }
     }
 
     if (output.length > 0) {
       const changelogPath = path.resolve(cwd, "CHANGELOG.md");
-      await fs.writeFile(changelogPath, output);
+      await updateChangelog(changelogPath, output, "Changelog", prettierConfig);
+      touchedFiles.push(changelogPath);
     }
   }
 

--- a/packages/apply-release-plan/src/types.ts
+++ b/packages/apply-release-plan/src/types.ts
@@ -5,3 +5,8 @@ export type RelevantChangesets = {
   minor: NewChangeset[];
   patch: NewChangeset[];
 };
+
+export type ChangelogEntry = {
+  title: string;
+  body: string;
+} | null;

--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -6,6 +6,7 @@ import {
 import getVersionRangeType from "@changesets/get-version-range-type";
 import { Range } from "semver";
 import { shouldUpdateDependencyBasedOnConfig } from "./utils";
+import { ChangelogEntry } from "./types";
 
 const DEPENDENCY_TYPES = [
   "dependencies",
@@ -16,7 +17,7 @@ const DEPENDENCY_TYPES = [
 
 export default function versionPackage(
   release: ComprehensiveRelease & {
-    changelog: string | null;
+    changelog: ChangelogEntry;
     packageJson: PackageJSON;
     dir: string;
   },

--- a/packages/cli/src/commands/version/index.ts
+++ b/packages/cli/src/commands/version/index.ts
@@ -23,6 +23,7 @@ export default async function version(
   cwd: string,
   options: {
     snapshot?: string | boolean;
+    output?: boolean;
   },
   config: Config
 ) {
@@ -71,12 +72,7 @@ export default async function version(
     options.snapshot
   );
 
-  await applyReleasePlan(
-    releasePlan,
-    packages,
-    releaseConfig,
-    options.snapshot
-  );
+  await applyReleasePlan(releasePlan, packages, releaseConfig, options);
 
   if (releaseConfig.commit) {
     log("All files have been updated and committed. You're ready to publish!");

--- a/packages/cli/src/commands/version/index.ts
+++ b/packages/cli/src/commands/version/index.ts
@@ -23,7 +23,7 @@ export default async function version(
   cwd: string,
   options: {
     snapshot?: string | boolean;
-    output?: boolean;
+    globalChangelog?: boolean;
   },
   config: Config
 ) {

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -160,7 +160,7 @@ export async function run(
           throw new ExitError(1);
         }
 
-        await version(cwd, { snapshot }, config);
+        await version(cwd, { snapshot, output: output !== undefined }, config);
         return;
       }
       case "publish": {

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -80,7 +80,8 @@ export async function run(
       empty,
       ignore,
       snapshot,
-      tag
+      tag,
+      globalChangelog
     }: CliOptions = flags;
     const deadFlags = ["updateChangelog", "isPublic", "skipCI", "commit"];
 
@@ -160,7 +161,7 @@ export async function run(
           throw new ExitError(1);
         }
 
-        await version(cwd, { snapshot, output: output !== undefined }, config);
+        await version(cwd, { snapshot, globalChangelog }, config);
         return;
       }
       case "publish": {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -13,6 +13,7 @@ export type CliOptions = {
   ignore?: string | string[];
   snapshot?: string | boolean;
   tag?: string;
+  globalChangelog?: boolean;
 };
 
 export type CommandOptions = CliOptions & {


### PR DESCRIPTION
Hi all! I'd been meaning to work on functionality mentioned in #200, #264, and #387 for awhile now, and finally had a chance to take a look. I wanted to open this as a draft to get some feedback on this approach, as something feels off to me about this.

As of right now, this functionality is attached to the `version` command by means of the `--globalChangelog` flag, which naively places `CHANGELOG.md` at the root of `cwd`. I've tested this with the [`chakra-ui`](https://github.com/chakra-ui/chakra-ui) repo, so I can verify that it works correctly. You can see the output of that here: https://gist.github.com/with-heart/ebdb9e9e74b3f84e221111d12c3723ca

# Changes
- Modified `generateMarkdown` to return `{title: string, body: string}` rather than `string`. This was needed because `title` is normally `## X.Y.Z` in the individual packages, but we'd want this to be `<package-name>@X.Y.Z` in a global changelog similar to how it works with "Version Packages" PRs.
- Modified existing individual package changelog generation within `applyReleasePlan` to utilize above change in data shape
- Added a new section to `applyReleasePlan` that combines the individual changelogs into a single `CHANGELOG.md`

# Questions/Issues
- Does it still make sense to start by collecting changelogs as markdown?

#200 mentions outputting a "'release info' thing", but it seems weird to me that the output of this would be a markdown file, which is a fairly static piece of output instead of something like a json file. In my mind, a nice opportunity for refactoring the releases->changelogs process would be to come up with a metadata object that those changelogs are built from, with the additional benefit that the output artifact could be a json file, which would allow anyone to consume it to produce whatever they wanted, whether that's a global changelog or something else.

- How do we envision configuration of the global changelog? With the Chakra global changelog, I think I'd want to sort the packages based on the highest version (packages with `major` changes come before packages with only `minor` changes come before packages with only `patch` changes), but I'm not sure how to easily allow that type of customization.