### PR TITLE
Add new config option for always upgrading internal dependents

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,5 +4,8 @@
     { "repo": "atlassian/changesets" }
   ],
   "commit": false,
-  "access": "public"
+  "access": "public",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "updateInternalDependents": "always"
+  }
 }

--- a/.changeset/light-buttons-chew.md
+++ b/.changeset/light-buttons-chew.md
@@ -1,6 +1,6 @@
 ---
 "@changesets/cli": minor
-"@changesets/config": major
+"@changesets/config": minor
 "@changesets/types": major
 ---
 

--- a/.changeset/light-buttons-chew.md
+++ b/.changeset/light-buttons-chew.md
@@ -1,0 +1,17 @@
+---
+"@changesets/cli": minor
+"@changesets/config": major
+"@changesets/types": major
+---
+
+A new `updateInternalDependents` experimental option has been added. It can be used to add dependent packages to the release (if they are not already a part of it) with patch bumps. To use it you can add this to your config:
+
+```json
+{
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "updateInternalDependents": "always"
+  }
+}
+```
+
+This option accepts two values - `"always"` and `"out-of-range"` (the latter matches the current default behavior).

--- a/.changeset/rare-balloons-kick.md
+++ b/.changeset/rare-balloons-kick.md
@@ -1,0 +1,7 @@
+---
+"@changesets/apply-release-plan": major
+"@changesets/assemble-release-plan": major
+"@changesets/get-release-plan": major
+---
+
+The accepted `Config` type has been changed - a new experimental option (`updateInternalDependents`) was added to it.

--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -6,6 +6,7 @@ Changesets has a minimal amount of configuration options. Mostly these are for w
 {
   "commit": false,
   "updateInternalDependencies": "patch",
+  "updateInternalDependents": false,
   "linked": [],
   "access": "restricted",
   "baseBranch": "master",
@@ -14,7 +15,7 @@ Changesets has a minimal amount of configuration options. Mostly these are for w
 }
 ```
 
-> NOTE: the `linked`, `updateInternalDependencies` and `ignore` options are only for behaviour in monorepos.
+> NOTE: the `linked`, `updateInternalDependencies`, `updateInternalDependents` and `ignore` options are only for behaviour in monorepos.
 
 ## `commit` (`true` | `false`)
 
@@ -98,6 +99,12 @@ pkg-b @ version 1.0.1
 Using `minor` allows consumers to more actively control their own deduplication of packages, and will allow them to install fewer versions if you have many interconnected packages. Using `patch` will mean consumers will more often be using more updated code, but may cause problems with deduplication.
 
 Changesets will always update the dependency if it would leave the old semver range.
+
+TODO: note that this only applies for packages released in the current release
+
+## `updateInternalDependents` boolean
+
+TODO:
 
 ## `changelog` (false or a path)
 

--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -6,7 +6,6 @@ Changesets has a minimal amount of configuration options. Mostly these are for w
 {
   "commit": false,
   "updateInternalDependencies": "patch",
-  "updateInternalDependents": false,
   "linked": [],
   "access": "restricted",
   "baseBranch": "master",
@@ -15,7 +14,7 @@ Changesets has a minimal amount of configuration options. Mostly these are for w
 }
 ```
 
-> NOTE: the `linked`, `updateInternalDependencies`, `updateInternalDependents` and `ignore` options are only for behaviour in monorepos.
+> NOTE: the `linked`, `updateInternalDependencies`, and `ignore` options are only for behaviour in monorepos.
 
 ## `commit` (`true` | `false`)
 
@@ -101,10 +100,6 @@ Using `minor` allows consumers to more actively control their own deduplication 
 Changesets will always update the dependency if it would leave the old semver range.
 
 TODO: note that this only applies for packages released in the current release
-
-## `updateInternalDependents` boolean
-
-TODO:
 
 ## `changelog` (false or a path)
 

--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -99,7 +99,7 @@ Using `minor` allows consumers to more actively control their own deduplication 
 
 Changesets will always update the dependency if it would leave the old semver range.
 
-TODO: note that this only applies for packages released in the current release
+> ⚠ Note: this is only applied for packages which are already released in the current release. If A depends on B and we only release B then A won't be bumped.
 
 ## `changelog` (false or a path)
 

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -46,7 +46,7 @@ class FakeReleasePlan {
       access: "restricted",
       baseBranch: "main",
       updateInternalDependencies: "patch",
-      updateInternalDependents: false,
+      updateInternalDependents: "out-of-range",
       ignore: [],
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
         onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -82,7 +82,7 @@ async function testSetup(
       access: "restricted",
       baseBranch: "main",
       updateInternalDependencies: "patch",
-      updateInternalDependents: false,
+      updateInternalDependents: "out-of-range",
       ignore: [],
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
         onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -416,7 +416,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          updateInternalDependents: false,
+          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -478,7 +478,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          updateInternalDependents: false,
+          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -626,7 +626,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: false,
+              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -710,7 +710,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: false,
+              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -786,7 +786,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: false,
+              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -862,7 +862,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: false,
+              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -941,7 +941,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: false,
+              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1025,7 +1025,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: false,
+              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1101,7 +1101,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: false,
+              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1177,7 +1177,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: false,
+              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1257,7 +1257,7 @@ describe("apply release plan", () => {
             access: "restricted",
             baseBranch: "main",
             updateInternalDependencies: "patch",
-            updateInternalDependents: false,
+            updateInternalDependents: "out-of-range",
             ignore: [],
             ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
               onlyUpdatePeerDependentsWhenOutOfRange: true,
@@ -1416,7 +1416,7 @@ describe("apply release plan", () => {
             null
           ],
           updateInternalDependencies: "patch",
-          updateInternalDependents: false,
+          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1520,7 +1520,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          updateInternalDependents: false,
+          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1602,7 +1602,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "minor",
-          updateInternalDependents: false,
+          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1688,7 +1688,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "minor",
-          updateInternalDependents: false,
+          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1787,7 +1787,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "minor",
-          updateInternalDependents: false,
+          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -2187,7 +2187,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          updateInternalDependents: false,
+          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -46,10 +46,10 @@ class FakeReleasePlan {
       access: "restricted",
       baseBranch: "main",
       updateInternalDependencies: "patch",
-      updateInternalDependents: "out-of-range",
       ignore: [],
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
         onlyUpdatePeerDependentsWhenOutOfRange: false,
+        updateInternalDependents: "out-of-range",
         useCalculatedVersionForSnapshots: false
       },
       ...config
@@ -82,10 +82,10 @@ async function testSetup(
       access: "restricted",
       baseBranch: "main",
       updateInternalDependencies: "patch",
-      updateInternalDependents: "out-of-range",
       ignore: [],
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
         onlyUpdatePeerDependentsWhenOutOfRange: false,
+        updateInternalDependents: "out-of-range",
         useCalculatedVersionForSnapshots: false
       }
     };
@@ -416,10 +416,10 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
+            updateInternalDependents: "out-of-range",
             useCalculatedVersionForSnapshots: false
           }
         }
@@ -478,10 +478,10 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
+            updateInternalDependents: "out-of-range",
             useCalculatedVersionForSnapshots: false
           }
         }
@@ -626,10 +626,10 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
+                updateInternalDependents: "out-of-range",
                 useCalculatedVersionForSnapshots: false
               }
             }
@@ -710,10 +710,10 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
+                updateInternalDependents: "out-of-range",
                 useCalculatedVersionForSnapshots: false
               }
             }
@@ -786,10 +786,10 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
+                updateInternalDependents: "out-of-range",
                 useCalculatedVersionForSnapshots: false
               }
             }
@@ -862,10 +862,10 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
+                updateInternalDependents: "out-of-range",
                 useCalculatedVersionForSnapshots: false
               }
             }
@@ -941,10 +941,10 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
+                updateInternalDependents: "out-of-range",
                 useCalculatedVersionForSnapshots: false
               }
             }
@@ -1025,10 +1025,10 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
+                updateInternalDependents: "out-of-range",
                 useCalculatedVersionForSnapshots: false
               }
             }
@@ -1101,10 +1101,10 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
+                updateInternalDependents: "out-of-range",
                 useCalculatedVersionForSnapshots: false
               }
             }
@@ -1177,10 +1177,10 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
-              updateInternalDependents: "out-of-range",
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
+                updateInternalDependents: "out-of-range",
                 useCalculatedVersionForSnapshots: false
               }
             }
@@ -1257,10 +1257,10 @@ describe("apply release plan", () => {
             access: "restricted",
             baseBranch: "main",
             updateInternalDependencies: "patch",
-            updateInternalDependents: "out-of-range",
             ignore: [],
             ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
               onlyUpdatePeerDependentsWhenOutOfRange: true,
+              updateInternalDependents: "out-of-range",
               useCalculatedVersionForSnapshots: false
             }
           }
@@ -1416,10 +1416,10 @@ describe("apply release plan", () => {
             null
           ],
           updateInternalDependencies: "patch",
-          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
+            updateInternalDependents: "out-of-range",
             useCalculatedVersionForSnapshots: false
           }
         }
@@ -1520,10 +1520,10 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
+            updateInternalDependents: "out-of-range",
             useCalculatedVersionForSnapshots: false
           }
         }
@@ -1602,10 +1602,10 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "minor",
-          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
+            updateInternalDependents: "out-of-range",
             useCalculatedVersionForSnapshots: false
           }
         }
@@ -1688,10 +1688,10 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "minor",
-          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
+            updateInternalDependents: "out-of-range",
             useCalculatedVersionForSnapshots: false
           }
         }
@@ -1787,10 +1787,10 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "minor",
-          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
+            updateInternalDependents: "out-of-range",
             useCalculatedVersionForSnapshots: false
           }
         }
@@ -2187,10 +2187,10 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
-          updateInternalDependents: "out-of-range",
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
+            updateInternalDependents: "out-of-range",
             useCalculatedVersionForSnapshots: false
           }
         }

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -46,6 +46,7 @@ class FakeReleasePlan {
       access: "restricted",
       baseBranch: "main",
       updateInternalDependencies: "patch",
+      updateInternalDependents: false,
       ignore: [],
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
         onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -81,6 +82,7 @@ async function testSetup(
       access: "restricted",
       baseBranch: "main",
       updateInternalDependencies: "patch",
+      updateInternalDependents: false,
       ignore: [],
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
         onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -414,6 +416,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
+          updateInternalDependents: false,
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -475,6 +478,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
+          updateInternalDependents: false,
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -622,6 +626,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
+              updateInternalDependents: false,
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -705,6 +710,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
+              updateInternalDependents: false,
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -780,6 +786,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
+              updateInternalDependents: false,
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -855,6 +862,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
+              updateInternalDependents: false,
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -933,6 +941,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
+              updateInternalDependents: false,
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1016,6 +1025,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
+              updateInternalDependents: false,
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1091,6 +1101,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
+              updateInternalDependents: false,
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1166,6 +1177,7 @@ describe("apply release plan", () => {
               access: "restricted",
               baseBranch: "main",
               updateInternalDependencies,
+              updateInternalDependents: false,
               ignore: [],
               ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
                 onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1245,6 +1257,7 @@ describe("apply release plan", () => {
             access: "restricted",
             baseBranch: "main",
             updateInternalDependencies: "patch",
+            updateInternalDependents: false,
             ignore: [],
             ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
               onlyUpdatePeerDependentsWhenOutOfRange: true,
@@ -1403,6 +1416,7 @@ describe("apply release plan", () => {
             null
           ],
           updateInternalDependencies: "patch",
+          updateInternalDependents: false,
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1506,6 +1520,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
+          updateInternalDependents: false,
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1587,6 +1602,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "minor",
+          updateInternalDependents: false,
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1672,6 +1688,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "minor",
+          updateInternalDependents: false,
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -1770,6 +1787,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "minor",
+          updateInternalDependents: false,
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -2169,6 +2187,7 @@ describe("apply release plan", () => {
           access: "restricted",
           baseBranch: "main",
           updateInternalDependencies: "patch",
+          updateInternalDependents: false,
           ignore: [],
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
             onlyUpdatePeerDependentsWhenOutOfRange: false,

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -140,7 +140,10 @@ export default async function applyReleasePlan(
     }
   }
 
-  if (releasePlan.preState?.mode === "exit") {
+  if (
+    releasePlan.preState === undefined ||
+    releasePlan.preState.mode === "exit"
+  ) {
     let changesetFolder = path.resolve(cwd, ".changeset");
     await Promise.all(
       changesets.map(async changeset => {

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -75,7 +75,7 @@ export default async function applyReleasePlan(
 
   const versionCommit = createVersionCommit(releasePlan, config.commit);
 
-  let releaseWithPackages = releases.map(release => {
+  let releasesWithPackage = releases.map(release => {
     let pkg = packagesByName.get(release.name);
     if (!pkg)
       throw new Error(
@@ -89,7 +89,7 @@ export default async function applyReleasePlan(
 
   // I think this might be the wrong place to do this, but gotta do it somewhere -  add changelog entries to releases
   let releaseWithChangelogs = await getNewChangelogEntry(
-    releaseWithPackages,
+    releasesWithPackage,
     changesets,
     config,
     cwd
@@ -140,10 +140,7 @@ export default async function applyReleasePlan(
     }
   }
 
-  if (
-    releasePlan.preState === undefined ||
-    releasePlan.preState.mode === "exit"
-  ) {
+  if (releasePlan.preState?.mode === "exit") {
     let changesetFolder = path.resolve(cwd, ".changeset");
     await Promise.all(
       changesets.map(async changeset => {

--- a/packages/assemble-release-plan/src/determine-dependents.ts
+++ b/packages/assemble-release-plan/src/determine-dependents.ts
@@ -3,7 +3,8 @@ import {
   Release,
   DependencyType,
   PackageJSON,
-  VersionType
+  VersionType,
+  Config
 } from "@changesets/types";
 import { Package } from "@manypkg/get-packages";
 import { InternalRelease, PreInfo } from "./types";
@@ -21,20 +22,18 @@ import { incrementVersion } from "./increment";
   We could solve this by inlining this function, or by returning a deep-cloned then
   modified array, but we decided both of those are worse than this solution.
 */
-export default function getDependents({
+export default function determineDependents({
   releases,
   packagesByName,
   dependencyGraph,
   preInfo,
-  ignoredPackages,
-  onlyUpdatePeerDependentsWhenOutOfRange
+  config
 }: {
   releases: Map<string, InternalRelease>;
   packagesByName: Map<string, Package>;
   dependencyGraph: Map<string, string[]>;
   preInfo: PreInfo | undefined;
-  ignoredPackages: Readonly<string[]>;
-  onlyUpdatePeerDependentsWhenOutOfRange: boolean;
+  config: Config;
 }): boolean {
   let updated = false;
   // NOTE this is intended to be called recursively
@@ -51,8 +50,6 @@ export default function getDependents({
         `Error in determining dependents - could not find package in repository: ${nextRelease.name}`
       );
     }
-    // For each dependent we are going to see whether it needs to be bumped because it's dependency
-    // is leaving the version range.
     pkgDependents
       .map(dependent => {
         let type: VersionType | undefined;
@@ -60,8 +57,7 @@ export default function getDependents({
         const dependentPackage = packagesByName.get(dependent);
         if (!dependentPackage) throw new Error("Dependency map is incorrect");
 
-        // If the dependent is an ignored package, we want to bump its dependencies without a release, so setting type to "none"
-        if (ignoredPackages.includes(dependent)) {
+        if (config.ignore.includes(dependent)) {
           type = "none";
         } else {
           const dependencyVersionRanges = getDependencyVersionRanges(
@@ -78,7 +74,9 @@ export default function getDependents({
                 releases,
                 nextRelease,
                 preInfo,
-                onlyUpdatePeerDependentsWhenOutOfRange
+                onlyUpdatePeerDependentsWhenOutOfRange:
+                  config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
+                    .onlyUpdatePeerDependentsWhenOutOfRange
               })
             ) {
               type = "major";
@@ -87,11 +85,12 @@ export default function getDependents({
                 // TODO validate this - I don't think it's right anymore
                 (!releases.has(dependent) ||
                   releases.get(dependent)!.type === "none") &&
-                !semver.satisfies(
-                  incrementVersion(nextRelease, preInfo),
-                  // to deal with a * versionRange that comes from workspace:* dependencies as the wildcard will match anything
-                  versionRange === "*" ? nextRelease.oldVersion : versionRange
-                )
+                (config.updateInternalDependents ||
+                  !semver.satisfies(
+                    incrementVersion(nextRelease, preInfo),
+                    // to deal with a * versionRange that comes from workspace:* dependencies as the wildcard will match anything
+                    versionRange === "*" ? nextRelease.oldVersion : versionRange
+                  ))
               ) {
                 switch (depType) {
                   case "dependencies":
@@ -119,7 +118,11 @@ export default function getDependents({
         if (releases.has(dependent) && releases.get(dependent)!.type === type) {
           type = undefined;
         }
-        return { name: dependent, type, pkgJSON: dependentPackage.packageJson };
+        return {
+          name: dependent,
+          type,
+          pkgJSON: dependentPackage.packageJson
+        };
       })
       .filter(({ type }) => type)
       .forEach(

--- a/packages/assemble-release-plan/src/determine-dependents.ts
+++ b/packages/assemble-release-plan/src/determine-dependents.ts
@@ -85,7 +85,8 @@ export default function determineDependents({
                 // TODO validate this - I don't think it's right anymore
                 (!releases.has(dependent) ||
                   releases.get(dependent)!.type === "none") &&
-                (config.updateInternalDependents === "always" ||
+                (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
+                  .updateInternalDependents === "always" ||
                   !semver.satisfies(
                     incrementVersion(nextRelease, preInfo),
                     // to deal with a * versionRange that comes from workspace:* dependencies as the wildcard will match anything

--- a/packages/assemble-release-plan/src/determine-dependents.ts
+++ b/packages/assemble-release-plan/src/determine-dependents.ts
@@ -85,7 +85,7 @@ export default function determineDependents({
                 // TODO validate this - I don't think it's right anymore
                 (!releases.has(dependent) ||
                   releases.get(dependent)!.type === "none") &&
-                (config.updateInternalDependents ||
+                (config.updateInternalDependents === "always" ||
                   !semver.satisfies(
                     incrementVersion(nextRelease, preInfo),
                     // to deal with a * versionRange that comes from workspace:* dependencies as the wildcard will match anything

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -16,8 +16,7 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toBe(1);
@@ -42,8 +41,7 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toBe(4);
@@ -65,8 +63,7 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toEqual(1);
@@ -84,8 +81,7 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toEqual(2);
@@ -103,15 +99,10 @@ describe("assemble-release-plan", () => {
       releases: [{ name: "pkg-a", type: "major" }]
     });
 
-    let { releases } = assembleReleasePlan(
-      setup.changesets,
-      setup.packages,
-      {
-        ...defaultConfig,
-        bumpVersionsWithWorkspaceProtocolOnly: true
-      },
-      undefined
-    );
+    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+      ...defaultConfig,
+      bumpVersionsWithWorkspaceProtocolOnly: true
+    });
 
     expect(releases.length).toEqual(2);
     expect(releases[0].name).toEqual("pkg-a");
@@ -130,8 +121,7 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toEqual(2);
@@ -154,8 +144,7 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toEqual(3);
@@ -197,8 +186,7 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toEqual(1);
@@ -215,8 +203,7 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toEqual(1);
@@ -229,12 +216,10 @@ describe("assemble-release-plan", () => {
       releases: [{ name: "pkg-b", type: "major" }]
     });
 
-    let { releases } = assembleReleasePlan(
-      setup.changesets,
-      setup.packages,
-      { ...defaultConfig, linked: [["pkg-a", "pkg-b"]] },
-      undefined
-    );
+    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+      ...defaultConfig,
+      linked: [["pkg-a", "pkg-b"]]
+    });
 
     expect(releases.length).toEqual(2);
     expect(releases[0].newVersion).toEqual("2.0.0");
@@ -251,12 +236,10 @@ describe("assemble-release-plan", () => {
 
     setup.updatePackage("pkg-c", "2.0.0");
 
-    let { releases } = assembleReleasePlan(
-      setup.changesets,
-      setup.packages,
-      { ...defaultConfig, linked: [["pkg-a", "pkg-b", "pkg-c"]] },
-      undefined
-    );
+    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+      ...defaultConfig,
+      linked: [["pkg-a", "pkg-b", "pkg-c"]]
+    });
 
     expect(releases.length).toEqual(2);
     expect(releases[0].newVersion).toEqual("2.1.0");
@@ -281,18 +264,13 @@ describe("assemble-release-plan", () => {
 
     setup.updateDependency("pkg-c", "pkg-a", "^1.0.0");
 
-    let { releases } = assembleReleasePlan(
-      setup.changesets,
-      setup.packages,
-      {
-        ...defaultConfig,
-        linked: [
-          ["pkg-a", "pkg-b"],
-          ["pkg-c", "pkg-d"]
-        ]
-      },
-      undefined
-    );
+    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+      ...defaultConfig,
+      linked: [
+        ["pkg-a", "pkg-b"],
+        ["pkg-c", "pkg-d"]
+      ]
+    });
 
     expect(releases.length).toEqual(4);
     expect(releases[0].newVersion).toEqual("2.0.0");
@@ -301,18 +279,13 @@ describe("assemble-release-plan", () => {
     expect(releases[3].newVersion).toEqual("1.1.0");
   });
   it("should return an empty release array when no chnages will occur", () => {
-    let { releases } = assembleReleasePlan(
-      [],
-      setup.packages,
-      {
-        ...defaultConfig,
-        linked: [
-          ["pkg-a", "pkg-b"],
-          ["pkg-c", "pkg-d"]
-        ]
-      },
-      undefined
-    );
+    let { releases } = assembleReleasePlan([], setup.packages, {
+      ...defaultConfig,
+      linked: [
+        ["pkg-a", "pkg-b"],
+        ["pkg-c", "pkg-d"]
+      ]
+    });
 
     expect(releases).toEqual([]);
   });
@@ -320,18 +293,13 @@ describe("assemble-release-plan", () => {
     setup.updateDependency("pkg-b", "pkg-a", "1.0.0");
     setup.updateDependency("pkg-c", "pkg-a", "1.0.0");
 
-    let { releases } = assembleReleasePlan(
-      setup.changesets,
-      setup.packages,
-      {
-        ...defaultConfig,
-        linked: [
-          ["pkg-a", "pkg-b"],
-          ["pkg-c", "pkg-d"]
-        ]
-      },
-      undefined
-    );
+    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+      ...defaultConfig,
+      linked: [
+        ["pkg-a", "pkg-b"],
+        ["pkg-c", "pkg-d"]
+      ]
+    });
 
     expect(releases.length).toEqual(3);
     expect(releases[0].name).toEqual("pkg-a");
@@ -345,18 +313,13 @@ describe("assemble-release-plan", () => {
     setup.updateDependency("pkg-b", "pkg-a", "1.0.0");
     setup.updateDependency("pkg-c", "pkg-b", "1.0.0");
 
-    let { releases } = assembleReleasePlan(
-      setup.changesets,
-      setup.packages,
-      {
-        ...defaultConfig,
-        linked: [
-          ["pkg-a", "pkg-b"],
-          ["pkg-c", "pkg-d"]
-        ]
-      },
-      undefined
-    );
+    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+      ...defaultConfig,
+      linked: [
+        ["pkg-a", "pkg-b"],
+        ["pkg-c", "pkg-d"]
+      ]
+    });
 
     expect(releases.length).toEqual(3);
     expect(releases[0].name).toEqual("pkg-a");
@@ -368,19 +331,17 @@ describe("assemble-release-plan", () => {
   });
 
   it("should bump peer dependents where the version is updated because of linked", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "1.0.0");
+    setup.updatePeerDependency("pkg-b", "pkg-a", "1.0.0");
 
     setup.addChangeset({
       id: "some-id",
       releases: [{ type: "minor", name: "pkg-c" }]
     });
 
-    let { releases } = assembleReleasePlan(
-      setup.changesets,
-      setup.packages,
-      { ...defaultConfig, linked: [["pkg-a", "pkg-c"]] },
-      undefined
-    );
+    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+      ...defaultConfig,
+      linked: [["pkg-a", "pkg-c"]]
+    });
 
     expect(releases).toMatchObject([
       {
@@ -398,7 +359,7 @@ describe("assemble-release-plan", () => {
     ]);
   });
   it("should update a peerDep by a major bump", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "~1.0.0");
+    setup.updatePeerDependency("pkg-b", "pkg-a", "~1.0.0");
     setup.addChangeset({
       id: "nonsense-words-combine",
       releases: [{ name: "pkg-a", type: "minor" }]
@@ -407,8 +368,7 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toEqual(2);
@@ -426,15 +386,10 @@ describe("assemble-release-plan", () => {
       id: "small-dogs-sad",
       releases: [{ name: "pkg-b", type: "minor" }]
     });
-    const { releases } = assembleReleasePlan(
-      setup.changesets,
-      setup.packages,
-      {
-        ...defaultConfig,
-        ignore: ["pkg-b"]
-      },
-      undefined
-    );
+    const { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+      ...defaultConfig,
+      ignore: ["pkg-b"]
+    });
 
     expect(releases.length).toEqual(1);
     expect(releases[0].name).toEqual("pkg-a");
@@ -450,15 +405,10 @@ describe("assemble-release-plan", () => {
       id: "small-dogs-sad",
       releases: [{ name: "pkg-b", type: "minor" }]
     });
-    const { releases } = assembleReleasePlan(
-      setup.changesets,
-      setup.packages,
-      {
-        ...defaultConfig,
-        ignore: ["pkg-b"]
-      },
-      undefined
-    );
+    const { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+      ...defaultConfig,
+      ignore: ["pkg-b"]
+    });
 
     expect(releases.length).toEqual(2);
     expect(releases[0].name).toEqual("pkg-a");
@@ -468,7 +418,7 @@ describe("assemble-release-plan", () => {
     expect(releases[1].newVersion).toEqual("1.0.0");
   });
   it("should generate releases with 'none' release type for ignored packages through peerDependencies", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "1.0.0");
+    setup.updatePeerDependency("pkg-b", "pkg-a", "1.0.0");
     setup.addChangeset({
       id: "big-cats-delight",
       releases: [{ name: "pkg-a", type: "major" }]
@@ -477,15 +427,10 @@ describe("assemble-release-plan", () => {
       id: "small-dogs-sad",
       releases: [{ name: "pkg-b", type: "minor" }]
     });
-    const { releases } = assembleReleasePlan(
-      setup.changesets,
-      setup.packages,
-      {
-        ...defaultConfig,
-        ignore: ["pkg-b"]
-      },
-      undefined
-    );
+    const { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+      ...defaultConfig,
+      ignore: ["pkg-b"]
+    });
 
     expect(releases.length).toEqual(2);
     expect(releases[0].name).toEqual("pkg-a");
@@ -504,15 +449,10 @@ describe("assemble-release-plan", () => {
       id: "small-dogs-sad",
       releases: [{ name: "pkg-b", type: "minor" }]
     });
-    const { releases } = assembleReleasePlan(
-      setup.changesets,
-      setup.packages,
-      {
-        ...defaultConfig,
-        ignore: ["pkg-b"]
-      },
-      undefined
-    );
+    const { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+      ...defaultConfig,
+      ignore: ["pkg-b"]
+    });
 
     expect(releases.length).toEqual(2);
     expect(releases[0].name).toEqual("pkg-a");
@@ -532,15 +472,10 @@ describe("assemble-release-plan", () => {
     });
 
     expect(() =>
-      assembleReleasePlan(
-        setup.changesets,
-        setup.packages,
-        {
-          ...defaultConfig,
-          ignore: ["pkg-b"]
-        },
-        undefined
-      )
+      assembleReleasePlan(setup.changesets, setup.packages, {
+        ...defaultConfig,
+        ignore: ["pkg-b"]
+      })
     ).toThrowErrorMatchingInlineSnapshot(`
 "Found mixed changeset big-cats-delight
 Found ignored packages: pkg-b
@@ -695,8 +630,7 @@ describe("version update thoroughness", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
     expect(releases.length).toEqual(2);
     expect(releases[0].name).toEqual("pkg-a");
@@ -713,8 +647,7 @@ describe("version update thoroughness", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toEqual(3);
@@ -734,8 +667,7 @@ describe("version update thoroughness", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toEqual(4);
@@ -758,13 +690,12 @@ describe("bumping peerDeps", () => {
   });
 
   it("should patch a pinned peerDep", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "1.0.0");
+    setup.updatePeerDependency("pkg-b", "pkg-a", "1.0.0");
 
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toBe(2);
@@ -774,7 +705,7 @@ describe("bumping peerDeps", () => {
     expect(releases[1].newVersion).toEqual("1.0.1");
   });
   it("should not bump the dependent when bumping a tilde peerDep by none", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "~1.0.0");
+    setup.updatePeerDependency("pkg-b", "pkg-a", "~1.0.0");
     setup.changesets = [];
     setup.addChangeset({
       id: "anyway-the-windblows",
@@ -784,8 +715,7 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toBe(1);
@@ -793,13 +723,12 @@ describe("bumping peerDeps", () => {
     expect(releases[0].newVersion).toEqual("1.0.0");
   });
   it("should not bump the dependent when bumping a tilde peerDep by a patch", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "~1.0.0");
+    setup.updatePeerDependency("pkg-b", "pkg-a", "~1.0.0");
 
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toBe(1);
@@ -807,7 +736,7 @@ describe("bumping peerDeps", () => {
     expect(releases[0].newVersion).toEqual("1.0.1");
   });
   it("should major bump dependent when bumping a tilde peerDep by minor", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "~1.0.0");
+    setup.updatePeerDependency("pkg-b", "pkg-a", "~1.0.0");
     setup.addChangeset({
       id: "anyway-the-windblows",
       releases: [{ name: "pkg-a", type: "minor" }]
@@ -816,8 +745,7 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toBe(2);
@@ -827,7 +755,7 @@ describe("bumping peerDeps", () => {
     expect(releases[1].newVersion).toEqual("2.0.0");
   });
   it("should major bump dependent when bumping a tilde peerDep by major", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "~1.0.0");
+    setup.updatePeerDependency("pkg-b", "pkg-a", "~1.0.0");
     setup.addChangeset({
       id: "anyway-the-windblows",
       releases: [{ name: "pkg-a", type: "major" }]
@@ -836,8 +764,7 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toBe(2);
@@ -847,7 +774,7 @@ describe("bumping peerDeps", () => {
     expect(releases[1].newVersion).toEqual("2.0.0");
   });
   it("should not bump dependent when bumping caret peerDep by none", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "^1.0.0");
+    setup.updatePeerDependency("pkg-b", "pkg-a", "^1.0.0");
     setup.changesets = [];
     setup.addChangeset({
       id: "anyway-the-windblows",
@@ -857,8 +784,7 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toBe(1);
@@ -866,13 +792,12 @@ describe("bumping peerDeps", () => {
     expect(releases[0].newVersion).toEqual("1.0.0");
   });
   it("should not bump dependent when bumping caret peerDep by patch", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "^1.0.0");
+    setup.updatePeerDependency("pkg-b", "pkg-a", "^1.0.0");
 
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toBe(1);
@@ -880,7 +805,7 @@ describe("bumping peerDeps", () => {
     expect(releases[0].newVersion).toEqual("1.0.1");
   });
   it("should major bump dependent when bumping caret peerDep by minor", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "^1.0.0");
+    setup.updatePeerDependency("pkg-b", "pkg-a", "^1.0.0");
     setup.addChangeset({
       id: "anyway-the-windblows",
       releases: [{ name: "pkg-a", type: "minor" }]
@@ -889,8 +814,7 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toBe(2);
@@ -900,7 +824,7 @@ describe("bumping peerDeps", () => {
     expect(releases[1].newVersion).toEqual("2.0.0");
   });
   it("should major bump dependent when bumping caret peerDep by major", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "^1.0.0");
+    setup.updatePeerDependency("pkg-b", "pkg-a", "^1.0.0");
     setup.addChangeset({
       id: "anyway-the-windblows",
       releases: [{ name: "pkg-a", type: "major" }]
@@ -909,8 +833,7 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toBe(2);
@@ -920,7 +843,7 @@ describe("bumping peerDeps", () => {
     expect(releases[1].newVersion).toEqual("2.0.0");
   });
   it("should patch bump transitive dep that is only affected by peerDep bump", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "^1.0.0");
+    setup.updatePeerDependency("pkg-b", "pkg-a", "^1.0.0");
     setup.addPackage("pkg-c", "1.0.0");
     setup.updateDependency("pkg-c", "pkg-b", "^1.0.0");
     setup.addChangeset({
@@ -931,8 +854,7 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig,
-      undefined
+      defaultConfig
     );
 
     expect(releases.length).toBe(3);
@@ -952,48 +874,74 @@ describe("bumping peerDeps", () => {
 
   describe("onlyUpdatePeerDependentsWhenOutOfRange: true", () => {
     it("should not bump dependent when still in range", () => {
-      setup.updatePeerDep("pkg-b", "pkg-a", "^1.0.0");
+      setup.updatePeerDependency("pkg-b", "pkg-a", "^1.0.0");
       setup.addChangeset({
         id: "anyway-the-windblows",
         releases: [{ name: "pkg-a", type: "minor" }]
       });
-      let { releases } = assembleReleasePlan(
-        setup.changesets,
-        setup.packages,
-        {
-          ...defaultConfig,
-          ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-            onlyUpdatePeerDependentsWhenOutOfRange: true,
-            useCalculatedVersionForSnapshots: false
-          }
-        },
-        undefined
-      );
+      let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+        ...defaultConfig,
+        ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+          onlyUpdatePeerDependentsWhenOutOfRange: true,
+          useCalculatedVersionForSnapshots: false
+        }
+      });
       expect(releases.length).toBe(1);
       expect(releases[0].name).toEqual("pkg-a");
       expect(releases[0].newVersion).toEqual("1.1.0");
     });
   });
 
+  describe("updateInternalDependents", () => {
+    it("should bump a direct dependent when a dependency package gets bumped", () => {
+      setup.updateDependency("pkg-b", "pkg-a", "^1.0.0");
+
+      let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+        ...defaultConfig,
+        updateInternalDependents: true
+      });
+
+      expect(releases.length).toBe(2);
+      expect(releases[0].name).toEqual("pkg-a");
+      expect(releases[0].newVersion).toEqual("1.0.1");
+      expect(releases[1].name).toEqual("pkg-b");
+      expect(releases[1].newVersion).toEqual("1.0.1");
+    });
+
+    it("should bump a transitive dependent when a dependency package gets bumped", () => {
+      setup.addPackage("pkg-c", "1.0.0");
+      setup.updateDependency("pkg-b", "pkg-a", "^1.0.0");
+      setup.updateDependency("pkg-c", "pkg-b", "^1.0.0");
+
+      let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+        ...defaultConfig,
+        updateInternalDependents: true
+      });
+
+      expect(releases.length).toBe(3);
+      expect(releases[0].name).toEqual("pkg-a");
+      expect(releases[0].newVersion).toEqual("1.0.1");
+      expect(releases[1].name).toEqual("pkg-b");
+      expect(releases[1].newVersion).toEqual("1.0.1");
+      expect(releases[2].name).toEqual("pkg-c");
+      expect(releases[2].newVersion).toEqual("1.0.1");
+    });
+  });
+
   it("should major bump dependent when leaving range", () => {
-    setup.updatePeerDep("pkg-b", "pkg-a", "~1.0.0");
+    setup.updatePeerDependency("pkg-b", "pkg-a", "~1.0.0");
     setup.addChangeset({
       id: "anyway-the-windblows",
       releases: [{ name: "pkg-a", type: "minor" }]
     });
 
-    let { releases } = assembleReleasePlan(
-      setup.changesets,
-      setup.packages,
-      {
-        ...defaultConfig,
-        ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-          onlyUpdatePeerDependentsWhenOutOfRange: true,
-          useCalculatedVersionForSnapshots: false
-        }
-      },
-      undefined
-    );
+    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
+      ...defaultConfig,
+      ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+        onlyUpdatePeerDependentsWhenOutOfRange: true,
+        useCalculatedVersionForSnapshots: false
+      }
+    });
 
     expect(releases.length).toBe(2);
     expect(releases[0].name).toEqual("pkg-a");

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -892,13 +892,13 @@ describe("bumping peerDeps", () => {
     });
   });
 
-  describe("updateInternalDependents", () => {
+  describe("updateInternalDependents: always", () => {
     it("should bump a direct dependent when a dependency package gets bumped", () => {
       setup.updateDependency("pkg-b", "pkg-a", "^1.0.0");
 
       let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
         ...defaultConfig,
-        updateInternalDependents: true
+        updateInternalDependents: "always"
       });
 
       expect(releases.length).toBe(2);
@@ -915,7 +915,7 @@ describe("bumping peerDeps", () => {
 
       let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
         ...defaultConfig,
-        updateInternalDependents: true
+        updateInternalDependents: "always"
       });
 
       expect(releases.length).toBe(3);

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -16,7 +16,8 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toBe(1);
@@ -41,7 +42,8 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toBe(4);
@@ -63,7 +65,8 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toEqual(1);
@@ -81,7 +84,8 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toEqual(2);
@@ -99,10 +103,15 @@ describe("assemble-release-plan", () => {
       releases: [{ name: "pkg-a", type: "major" }]
     });
 
-    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-      ...defaultConfig,
-      bumpVersionsWithWorkspaceProtocolOnly: true
-    });
+    let { releases } = assembleReleasePlan(
+      setup.changesets,
+      setup.packages,
+      {
+        ...defaultConfig,
+        bumpVersionsWithWorkspaceProtocolOnly: true
+      },
+      undefined
+    );
 
     expect(releases.length).toEqual(2);
     expect(releases[0].name).toEqual("pkg-a");
@@ -121,7 +130,8 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toEqual(2);
@@ -144,7 +154,8 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toEqual(3);
@@ -186,7 +197,8 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toEqual(1);
@@ -203,7 +215,8 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toEqual(1);
@@ -216,10 +229,15 @@ describe("assemble-release-plan", () => {
       releases: [{ name: "pkg-b", type: "major" }]
     });
 
-    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-      ...defaultConfig,
-      linked: [["pkg-a", "pkg-b"]]
-    });
+    let { releases } = assembleReleasePlan(
+      setup.changesets,
+      setup.packages,
+      {
+        ...defaultConfig,
+        linked: [["pkg-a", "pkg-b"]]
+      },
+      undefined
+    );
 
     expect(releases.length).toEqual(2);
     expect(releases[0].newVersion).toEqual("2.0.0");
@@ -236,10 +254,15 @@ describe("assemble-release-plan", () => {
 
     setup.updatePackage("pkg-c", "2.0.0");
 
-    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-      ...defaultConfig,
-      linked: [["pkg-a", "pkg-b", "pkg-c"]]
-    });
+    let { releases } = assembleReleasePlan(
+      setup.changesets,
+      setup.packages,
+      {
+        ...defaultConfig,
+        linked: [["pkg-a", "pkg-b", "pkg-c"]]
+      },
+      undefined
+    );
 
     expect(releases.length).toEqual(2);
     expect(releases[0].newVersion).toEqual("2.1.0");
@@ -264,13 +287,18 @@ describe("assemble-release-plan", () => {
 
     setup.updateDependency("pkg-c", "pkg-a", "^1.0.0");
 
-    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-      ...defaultConfig,
-      linked: [
-        ["pkg-a", "pkg-b"],
-        ["pkg-c", "pkg-d"]
-      ]
-    });
+    let { releases } = assembleReleasePlan(
+      setup.changesets,
+      setup.packages,
+      {
+        ...defaultConfig,
+        linked: [
+          ["pkg-a", "pkg-b"],
+          ["pkg-c", "pkg-d"]
+        ]
+      },
+      undefined
+    );
 
     expect(releases.length).toEqual(4);
     expect(releases[0].newVersion).toEqual("2.0.0");
@@ -279,13 +307,18 @@ describe("assemble-release-plan", () => {
     expect(releases[3].newVersion).toEqual("1.1.0");
   });
   it("should return an empty release array when no chnages will occur", () => {
-    let { releases } = assembleReleasePlan([], setup.packages, {
-      ...defaultConfig,
-      linked: [
-        ["pkg-a", "pkg-b"],
-        ["pkg-c", "pkg-d"]
-      ]
-    });
+    let { releases } = assembleReleasePlan(
+      [],
+      setup.packages,
+      {
+        ...defaultConfig,
+        linked: [
+          ["pkg-a", "pkg-b"],
+          ["pkg-c", "pkg-d"]
+        ]
+      },
+      undefined
+    );
 
     expect(releases).toEqual([]);
   });
@@ -293,13 +326,18 @@ describe("assemble-release-plan", () => {
     setup.updateDependency("pkg-b", "pkg-a", "1.0.0");
     setup.updateDependency("pkg-c", "pkg-a", "1.0.0");
 
-    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-      ...defaultConfig,
-      linked: [
-        ["pkg-a", "pkg-b"],
-        ["pkg-c", "pkg-d"]
-      ]
-    });
+    let { releases } = assembleReleasePlan(
+      setup.changesets,
+      setup.packages,
+      {
+        ...defaultConfig,
+        linked: [
+          ["pkg-a", "pkg-b"],
+          ["pkg-c", "pkg-d"]
+        ]
+      },
+      undefined
+    );
 
     expect(releases.length).toEqual(3);
     expect(releases[0].name).toEqual("pkg-a");
@@ -313,13 +351,18 @@ describe("assemble-release-plan", () => {
     setup.updateDependency("pkg-b", "pkg-a", "1.0.0");
     setup.updateDependency("pkg-c", "pkg-b", "1.0.0");
 
-    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-      ...defaultConfig,
-      linked: [
-        ["pkg-a", "pkg-b"],
-        ["pkg-c", "pkg-d"]
-      ]
-    });
+    let { releases } = assembleReleasePlan(
+      setup.changesets,
+      setup.packages,
+      {
+        ...defaultConfig,
+        linked: [
+          ["pkg-a", "pkg-b"],
+          ["pkg-c", "pkg-d"]
+        ]
+      },
+      undefined
+    );
 
     expect(releases.length).toEqual(3);
     expect(releases[0].name).toEqual("pkg-a");
@@ -338,10 +381,15 @@ describe("assemble-release-plan", () => {
       releases: [{ type: "minor", name: "pkg-c" }]
     });
 
-    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-      ...defaultConfig,
-      linked: [["pkg-a", "pkg-c"]]
-    });
+    let { releases } = assembleReleasePlan(
+      setup.changesets,
+      setup.packages,
+      {
+        ...defaultConfig,
+        linked: [["pkg-a", "pkg-c"]]
+      },
+      undefined
+    );
 
     expect(releases).toMatchObject([
       {
@@ -368,7 +416,8 @@ describe("assemble-release-plan", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toEqual(2);
@@ -386,10 +435,15 @@ describe("assemble-release-plan", () => {
       id: "small-dogs-sad",
       releases: [{ name: "pkg-b", type: "minor" }]
     });
-    const { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-      ...defaultConfig,
-      ignore: ["pkg-b"]
-    });
+    const { releases } = assembleReleasePlan(
+      setup.changesets,
+      setup.packages,
+      {
+        ...defaultConfig,
+        ignore: ["pkg-b"]
+      },
+      undefined
+    );
 
     expect(releases.length).toEqual(1);
     expect(releases[0].name).toEqual("pkg-a");
@@ -405,10 +459,15 @@ describe("assemble-release-plan", () => {
       id: "small-dogs-sad",
       releases: [{ name: "pkg-b", type: "minor" }]
     });
-    const { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-      ...defaultConfig,
-      ignore: ["pkg-b"]
-    });
+    const { releases } = assembleReleasePlan(
+      setup.changesets,
+      setup.packages,
+      {
+        ...defaultConfig,
+        ignore: ["pkg-b"]
+      },
+      undefined
+    );
 
     expect(releases.length).toEqual(2);
     expect(releases[0].name).toEqual("pkg-a");
@@ -427,10 +486,15 @@ describe("assemble-release-plan", () => {
       id: "small-dogs-sad",
       releases: [{ name: "pkg-b", type: "minor" }]
     });
-    const { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-      ...defaultConfig,
-      ignore: ["pkg-b"]
-    });
+    const { releases } = assembleReleasePlan(
+      setup.changesets,
+      setup.packages,
+      {
+        ...defaultConfig,
+        ignore: ["pkg-b"]
+      },
+      undefined
+    );
 
     expect(releases.length).toEqual(2);
     expect(releases[0].name).toEqual("pkg-a");
@@ -449,10 +513,15 @@ describe("assemble-release-plan", () => {
       id: "small-dogs-sad",
       releases: [{ name: "pkg-b", type: "minor" }]
     });
-    const { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-      ...defaultConfig,
-      ignore: ["pkg-b"]
-    });
+    const { releases } = assembleReleasePlan(
+      setup.changesets,
+      setup.packages,
+      {
+        ...defaultConfig,
+        ignore: ["pkg-b"]
+      },
+      undefined
+    );
 
     expect(releases.length).toEqual(2);
     expect(releases[0].name).toEqual("pkg-a");
@@ -472,10 +541,15 @@ describe("assemble-release-plan", () => {
     });
 
     expect(() =>
-      assembleReleasePlan(setup.changesets, setup.packages, {
-        ...defaultConfig,
-        ignore: ["pkg-b"]
-      })
+      assembleReleasePlan(
+        setup.changesets,
+        setup.packages,
+        {
+          ...defaultConfig,
+          ignore: ["pkg-b"]
+        },
+        undefined
+      )
     ).toThrowErrorMatchingInlineSnapshot(`
 "Found mixed changeset big-cats-delight
 Found ignored packages: pkg-b
@@ -630,7 +704,8 @@ describe("version update thoroughness", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
     expect(releases.length).toEqual(2);
     expect(releases[0].name).toEqual("pkg-a");
@@ -647,7 +722,8 @@ describe("version update thoroughness", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toEqual(3);
@@ -667,7 +743,8 @@ describe("version update thoroughness", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toEqual(4);
@@ -695,7 +772,8 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toBe(2);
@@ -715,7 +793,8 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toBe(1);
@@ -728,7 +807,8 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toBe(1);
@@ -745,7 +825,8 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toBe(2);
@@ -764,7 +845,8 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toBe(2);
@@ -784,7 +866,8 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toBe(1);
@@ -797,7 +880,8 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toBe(1);
@@ -814,7 +898,8 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toBe(2);
@@ -833,7 +918,8 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toBe(2);
@@ -854,7 +940,8 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(
       setup.changesets,
       setup.packages,
-      defaultConfig
+      defaultConfig,
+      undefined
     );
 
     expect(releases.length).toBe(3);
@@ -879,13 +966,18 @@ describe("bumping peerDeps", () => {
         id: "anyway-the-windblows",
         releases: [{ name: "pkg-a", type: "minor" }]
       });
-      let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-        ...defaultConfig,
-        ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-          ...defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
-          onlyUpdatePeerDependentsWhenOutOfRange: true
-        }
-      });
+      let { releases } = assembleReleasePlan(
+        setup.changesets,
+        setup.packages,
+        {
+          ...defaultConfig,
+          ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+            ...defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
+            onlyUpdatePeerDependentsWhenOutOfRange: true
+          }
+        },
+        undefined
+      );
       expect(releases.length).toBe(1);
       expect(releases[0].name).toEqual("pkg-a");
       expect(releases[0].newVersion).toEqual("1.1.0");
@@ -896,13 +988,18 @@ describe("bumping peerDeps", () => {
     it("should bump a direct dependent when a dependency package gets bumped", () => {
       setup.updateDependency("pkg-b", "pkg-a", "^1.0.0");
 
-      let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-        ...defaultConfig,
-        ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-          ...defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
-          updateInternalDependents: "always"
-        }
-      });
+      let { releases } = assembleReleasePlan(
+        setup.changesets,
+        setup.packages,
+        {
+          ...defaultConfig,
+          ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+            ...defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
+            updateInternalDependents: "always"
+          }
+        },
+        undefined
+      );
 
       expect(releases.length).toBe(2);
       expect(releases[0].name).toEqual("pkg-a");
@@ -916,13 +1013,18 @@ describe("bumping peerDeps", () => {
       setup.updateDependency("pkg-b", "pkg-a", "^1.0.0");
       setup.updateDependency("pkg-c", "pkg-b", "^1.0.0");
 
-      let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-        ...defaultConfig,
-        ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-          ...defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
-          updateInternalDependents: "always"
-        }
-      });
+      let { releases } = assembleReleasePlan(
+        setup.changesets,
+        setup.packages,
+        {
+          ...defaultConfig,
+          ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+            ...defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
+            updateInternalDependents: "always"
+          }
+        },
+        undefined
+      );
 
       expect(releases.length).toBe(3);
       expect(releases[0].name).toEqual("pkg-a");
@@ -941,13 +1043,18 @@ describe("bumping peerDeps", () => {
       releases: [{ name: "pkg-a", type: "minor" }]
     });
 
-    let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
-      ...defaultConfig,
-      ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-        ...defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
-        onlyUpdatePeerDependentsWhenOutOfRange: true
-      }
-    });
+    let { releases } = assembleReleasePlan(
+      setup.changesets,
+      setup.packages,
+      {
+        ...defaultConfig,
+        ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+          ...defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
+          onlyUpdatePeerDependentsWhenOutOfRange: true
+        }
+      },
+      undefined
+    );
 
     expect(releases.length).toBe(2);
     expect(releases[0].name).toEqual("pkg-a");

--- a/packages/assemble-release-plan/src/index.test.ts
+++ b/packages/assemble-release-plan/src/index.test.ts
@@ -882,8 +882,8 @@ describe("bumping peerDeps", () => {
       let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
         ...defaultConfig,
         ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-          onlyUpdatePeerDependentsWhenOutOfRange: true,
-          useCalculatedVersionForSnapshots: false
+          ...defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
+          onlyUpdatePeerDependentsWhenOutOfRange: true
         }
       });
       expect(releases.length).toBe(1);
@@ -898,7 +898,10 @@ describe("bumping peerDeps", () => {
 
       let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
         ...defaultConfig,
-        updateInternalDependents: "always"
+        ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+          ...defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
+          updateInternalDependents: "always"
+        }
       });
 
       expect(releases.length).toBe(2);
@@ -915,7 +918,10 @@ describe("bumping peerDeps", () => {
 
       let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
         ...defaultConfig,
-        updateInternalDependents: "always"
+        ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+          ...defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
+          updateInternalDependents: "always"
+        }
       });
 
       expect(releases.length).toBe(3);
@@ -938,8 +944,8 @@ describe("bumping peerDeps", () => {
     let { releases } = assembleReleasePlan(setup.changesets, setup.packages, {
       ...defaultConfig,
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-        onlyUpdatePeerDependentsWhenOutOfRange: true,
-        useCalculatedVersionForSnapshots: false
+        ...defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
+        onlyUpdatePeerDependentsWhenOutOfRange: true
       }
     });
 

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -73,7 +73,8 @@ function assembleReleasePlan(
   changesets: NewChangeset[],
   packages: Packages,
   config: Config,
-  preState?: PreState,
+  // intentionally not using an optional parameter here so the result of `readPreState` has to be passed in here
+  preState: PreState | undefined,
   snapshot?: string | boolean
 ): ReleasePlan {
   let packagesByName = new Map(

--- a/packages/assemble-release-plan/src/index.ts
+++ b/packages/assemble-release-plan/src/index.ts
@@ -73,7 +73,7 @@ function assembleReleasePlan(
   changesets: NewChangeset[],
   packages: Packages,
   config: Config,
-  preState: PreState | undefined,
+  preState?: PreState,
   snapshot?: string | boolean
 ): ReleasePlan {
   let packagesByName = new Map(
@@ -113,10 +113,7 @@ function assembleReleasePlan(
       packagesByName,
       dependencyGraph,
       preInfo,
-      ignoredPackages: config.ignore,
-      onlyUpdatePeerDependentsWhenOutOfRange:
-        config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
-          .onlyUpdatePeerDependentsWhenOutOfRange
+      config
     });
 
     // The map passed in to determineDependents will be mutated

--- a/packages/assemble-release-plan/src/test-utils.ts
+++ b/packages/assemble-release-plan/src/test-utils.ts
@@ -1,10 +1,13 @@
 import { NewChangeset, Release, VersionType } from "@changesets/types";
 import { Package, Packages } from "@manypkg/get-packages";
 
-function getPackage(
-  name: string = "pkg-a",
-  version: string = "1.0.0"
-): Package {
+function getPackage({
+  name,
+  version
+}: {
+  name: string;
+  version: string;
+}): Package {
   return {
     packageJson: {
       name,
@@ -31,10 +34,13 @@ function getChangeset(
   };
 }
 
-function getRelease(data: { name?: string; type?: VersionType } = {}): Release {
-  let name = data.name || "pkg-a";
-  let type = data.type || "patch";
-
+function getRelease({
+  name,
+  type
+}: {
+  name: string;
+  type: VersionType;
+}): Release {
   return { name, type };
 }
 
@@ -47,10 +53,12 @@ let getSimpleSetup = () => ({
       },
       dir: "/"
     },
-    packages: [getPackage()],
+    packages: [getPackage({ name: "pkg-a", version: "1.0.0" })],
     tool: "yarn" as const
   },
-  changesets: [getChangeset({ releases: [getRelease()] })]
+  changesets: [
+    getChangeset({ releases: [getRelease({ name: "pkg-a", type: "patch" })] })
+  ]
 });
 
 class FakeFullState {
@@ -79,33 +87,33 @@ class FakeFullState {
     this.changesets.push(changeset);
   }
 
-  updateDependency(pkgA: string, pkgB: string, version: string) {
+  updateDependency(pkgA: string, pkgB: string, versionRange: string) {
     let pkg = this.packages.packages.find(a => a.packageJson.name === pkgA);
-    if (!pkg) throw new Error("no pkg");
+    if (!pkg) throw new Error(`No "${pkgA}" package`);
     if (!pkg.packageJson.dependencies) {
       pkg.packageJson.dependencies = {};
     }
-    pkg.packageJson.dependencies[pkgB] = version;
+    pkg.packageJson.dependencies[pkgB] = versionRange;
   }
-  updateDevDependency(pkgA: string, pkgB: string, version: string) {
+  updateDevDependency(pkgA: string, pkgB: string, versionRange: string) {
     let pkg = this.packages.packages.find(a => a.packageJson.name === pkgA);
-    if (!pkg) throw new Error("no pkg");
+    if (!pkg) throw new Error(`No "${pkgA}" package`);
     if (!pkg.packageJson.devDependencies) {
       pkg.packageJson.devDependencies = {};
     }
-    pkg.packageJson.devDependencies[pkgB] = version;
+    pkg.packageJson.devDependencies[pkgB] = versionRange;
   }
-  updatePeerDep(pkgA: string, pkgB: string, version: string) {
+  updatePeerDependency(pkgA: string, pkgB: string, versionRange: string) {
     let pkg = this.packages.packages.find(a => a.packageJson.name === pkgA);
-    if (!pkg) throw new Error("no pkg");
+    if (!pkg) throw new Error(`No "${pkgA}" package`);
     if (!pkg.packageJson.peerDependencies) {
       pkg.packageJson.peerDependencies = {};
     }
-    pkg.packageJson.peerDependencies[pkgB] = version;
+    pkg.packageJson.peerDependencies[pkgB] = versionRange;
   }
 
   addPackage(name: string, version: string) {
-    let pkg = getPackage(name, version);
+    let pkg = getPackage({ name, version });
     if (
       this.packages.packages.find(
         c => c.packageJson.name === pkg.packageJson.name

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -47,7 +47,9 @@ git.add.mockImplementation(() => Promise.resolve(true));
 // @ts-ignore
 git.commit.mockImplementation(() => Promise.resolve(true));
 // @ts-ignore
-git.getCommitsThatAddFiles.mockImplementation(() => Promise.resolve([]));
+git.getCommitsThatAddFiles.mockImplementation(changesetIds =>
+  Promise.resolve(changesetIds.map(() => "g1th4sh"))
+);
 // @ts-ignore
 git.tag.mockImplementation(() => Promise.resolve(true));
 
@@ -493,7 +495,7 @@ describe("updateInternalDependents", () => {
       ## 1.0.1
       ### Patch Changes
 
-      - Updated dependencies [undefined]
+      - Updated dependencies [g1th4sh]
         - pkg-b@1.0.1
       "
     `);
@@ -503,7 +505,7 @@ describe("updateInternalDependents", () => {
       ## 1.0.1
       ### Patch Changes
 
-      - This is not a summary
+      - g1th4sh: This is not a summary
       "
     `);
   });
@@ -641,68 +643,68 @@ describe("pre", () => {
         "utf8"
       )
     ).toMatchInlineSnapshot(`
-                                    "# pkg-a
+      "# pkg-a
 
-                                    ## 1.1.0
+      ## 1.1.0
 
-                                    ### Minor Changes
+      ### Minor Changes
 
-                                    - a very useful summary for the third change
+      - g1th4sh: a very useful summary for the third change
 
-                                    ### Patch Changes
+      ### Patch Changes
 
-                                    - a very useful summary
-                                    - a very useful summary for the second change
-                                    - Updated dependencies [undefined]
-                                      - pkg-b@1.0.1
+      - g1th4sh: a very useful summary
+      - g1th4sh: a very useful summary for the second change
+      - Updated dependencies [g1th4sh]
+        - pkg-b@1.0.1
 
-                                    ## 1.1.0-next.3
+      ## 1.1.0-next.3
 
-                                    ### Minor Changes
+      ### Minor Changes
 
-                                    - a very useful summary for the third change
+      - g1th4sh: a very useful summary for the third change
 
-                                    ## 1.0.1-next.2
+      ## 1.0.1-next.2
 
-                                    ### Patch Changes
+      ### Patch Changes
 
-                                    - a very useful summary for the second change
+      - g1th4sh: a very useful summary for the second change
 
-                                    ## 1.0.1-next.1
+      ## 1.0.1-next.1
 
-                                    ### Patch Changes
+      ### Patch Changes
 
-                                    - a very useful summary
+      - g1th4sh: a very useful summary
 
-                                    ## 1.0.1-next.0
+      ## 1.0.1-next.0
 
-                                    ### Patch Changes
+      ### Patch Changes
 
-                                    - Updated dependencies [undefined]
-                                      - pkg-b@1.0.1-next.0
-                                    "
-                        `);
+      - Updated dependencies [g1th4sh]
+        - pkg-b@1.0.1-next.0
+      "
+    `);
     expect(
       await fs.readFile(
         path.join(packages.packages[1].dir, "CHANGELOG.md"),
         "utf8"
       )
     ).toMatchInlineSnapshot(`
-                                                            "# pkg-b
+      "# pkg-b
 
-                                                            ## 1.0.1
+      ## 1.0.1
 
-                                                            ### Patch Changes
+      ### Patch Changes
 
-                                                            - a very useful summary for the first change
+      - g1th4sh: a very useful summary for the first change
 
-                                                            ## 1.0.1-next.0
+      ## 1.0.1-next.0
 
-                                                            ### Patch Changes
+      ### Patch Changes
 
-                                                            - a very useful summary for the first change
-                                                            "
-                                        `);
+      - g1th4sh: a very useful summary for the first change
+      "
+    `);
   });
   it("should work with adding a package while in pre mode", async () => {
     let cwd = f.copy("simple-project");

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -442,7 +442,7 @@ describe("snapshot release", () => {
           ...modifiedDefaultConfig,
           commit: false,
           ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-            onlyUpdatePeerDependentsWhenOutOfRange: false,
+            ...modifiedDefaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
             useCalculatedVersionForSnapshots: true
           }
         }
@@ -471,7 +471,10 @@ describe("updateInternalDependents: always", () => {
     await writeChangeset(simpleChangeset3, cwd);
     await versionCommand(cwd, defaultOptions, {
       ...modifiedDefaultConfig,
-      updateInternalDependents: "always"
+      ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+        ...defaultConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
+        updateInternalDependents: "always"
+      }
     });
 
     expect(getPkgJSON("pkg-a", spy.mock.calls)).toEqual(

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -464,14 +464,14 @@ describe("snapshot release", () => {
   });
 });
 
-describe("updateInternalDependents", () => {
+describe("updateInternalDependents: always", () => {
   it("should bump a direct dependent when a dependency package gets bumped", async () => {
     const cwd = await f.copy("simple-project-caret-dep");
     const spy = jest.spyOn(fs, "writeFile");
     await writeChangeset(simpleChangeset3, cwd);
     await versionCommand(cwd, defaultOptions, {
       ...modifiedDefaultConfig,
-      updateInternalDependents: true
+      updateInternalDependents: "always"
     });
 
     expect(getPkgJSON("pkg-a", spy.mock.calls)).toEqual(

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -279,8 +279,8 @@ describe("running version in a simple project", () => {
       await writeChangesets([simpleChangeset, simpleChangeset2], cwd);
       await versionCommand(cwd, defaultOptions, modifiedDefaultConfig);
 
-      const dirs = await fs.readdir(path.resolve(cwd, ".changeset"));
-      expect(dirs.length).toBe(2);
+      const files = await fs.readdir(path.resolve(cwd, ".changeset"));
+      expect(files.length).toBe(2);
     });
   });
 });

--- a/packages/config/schema.json
+++ b/packages/config/schema.json
@@ -67,11 +67,6 @@
       "type": "string",
       "description": "The minimum bump type to trigger automatic update of internal dependencies that are part of the same release.",
       "default": "patch"
-    },
-    "updateInternalDependents": {
-      "type": "boolean",
-      "description": "TODO",
-      "default": false
     }
   }
 }

--- a/packages/config/schema.json
+++ b/packages/config/schema.json
@@ -67,6 +67,11 @@
       "type": "string",
       "description": "The minimum bump type to trigger automatic update of internal dependencies that are part of the same release.",
       "default": "patch"
+    },
+    "updateInternalDependents": {
+      "type": "boolean",
+      "description": "TODO",
+      "default": false
     }
   }
 }

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -42,7 +42,7 @@ test("read reads the config", async () => {
     access: "restricted",
     baseBranch: "master",
     updateInternalDependencies: "patch",
-    updateInternalDependents: false,
+    updateInternalDependents: "out-of-range",
     ignore: [],
     bumpVersionsWithWorkspaceProtocolOnly: false,
     ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
@@ -59,7 +59,7 @@ let defaults = {
   access: "restricted",
   baseBranch: "master",
   updateInternalDependencies: "patch",
-  updateInternalDependents: false,
+  updateInternalDependents: "out-of-range",
   ignore: [],
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
     onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -228,11 +228,11 @@ let correctCases: Record<string, CorrectCase> = {
   },
   updateInternalDependents: {
     input: {
-      updateInternalDependents: true
+      updateInternalDependents: "always"
     },
     output: {
       ...defaults,
-      updateInternalDependents: true
+      updateInternalDependents: "always"
     }
   }
 };

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -42,6 +42,7 @@ test("read reads the config", async () => {
     access: "restricted",
     baseBranch: "master",
     updateInternalDependencies: "patch",
+    updateInternalDependents: false,
     ignore: [],
     bumpVersionsWithWorkspaceProtocolOnly: false,
     ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -58,6 +58,7 @@ let defaults = {
   access: "restricted",
   baseBranch: "master",
   updateInternalDependencies: "patch",
+  updateInternalDependents: false,
   ignore: [],
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
     onlyUpdatePeerDependentsWhenOutOfRange: false,
@@ -222,6 +223,15 @@ let correctCases: Record<string, CorrectCase> = {
     output: {
       ...defaults,
       ignore: ["pkg-a", "@pkg/a", "@pkg/b"]
+    }
+  },
+  updateInternalDependents: {
+    input: {
+      updateInternalDependents: true
+    },
+    output: {
+      ...defaults,
+      updateInternalDependents: true
     }
   }
 };

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -42,11 +42,11 @@ test("read reads the config", async () => {
     access: "restricted",
     baseBranch: "master",
     updateInternalDependencies: "patch",
-    updateInternalDependents: "out-of-range",
     ignore: [],
     bumpVersionsWithWorkspaceProtocolOnly: false,
     ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
       onlyUpdatePeerDependentsWhenOutOfRange: false,
+      updateInternalDependents: "out-of-range",
       useCalculatedVersionForSnapshots: false
     }
   });
@@ -59,10 +59,10 @@ let defaults = {
   access: "restricted",
   baseBranch: "master",
   updateInternalDependencies: "patch",
-  updateInternalDependents: "out-of-range",
   ignore: [],
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
     onlyUpdatePeerDependentsWhenOutOfRange: false,
+    updateInternalDependents: "out-of-range",
     useCalculatedVersionForSnapshots: false
   },
   bumpVersionsWithWorkspaceProtocolOnly: false
@@ -228,11 +228,16 @@ let correctCases: Record<string, CorrectCase> = {
   },
   updateInternalDependents: {
     input: {
-      updateInternalDependents: "always"
+      ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+        updateInternalDependents: "always"
+      }
     },
     output: {
       ...defaults,
-      updateInternalDependents: "always"
+      ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+        ...defaults.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
+        updateInternalDependents: "always"
+      }
     }
   }
 };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -16,7 +16,6 @@ export let defaultWrittenConfig = {
   access: "restricted",
   baseBranch: "master",
   updateInternalDependencies: "patch",
-  updateInternalDependents: "out-of-range",
   ignore: [] as ReadonlyArray<string>
 } as const;
 
@@ -333,8 +332,7 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
 
       updateInternalDependents:
         json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
-          ?.updateInternalDependents ??
-        defaultWrittenConfig.updateInternalDependents,
+          ?.updateInternalDependents ?? "out-of-range",
 
       useCalculatedVersionForSnapshots:
         json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH === undefined ||

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -194,18 +194,6 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
       )} but can only be 'patch' or 'minor'`
     );
   }
-  if (
-    json.updateInternalDependents !== undefined &&
-    !["always", "out-of-range"].includes(json.updateInternalDependents)
-  ) {
-    messages.push(
-      `The \`updateInternalDependents\` option is set as ${JSON.stringify(
-        json.updateInternalDependents,
-        null,
-        2
-      )} but can only be 'always' or 'out-of-range'`
-    );
-  }
   if (json.ignore) {
     if (
       !(
@@ -251,6 +239,7 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
   if (json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH !== undefined) {
     const {
       onlyUpdatePeerDependentsWhenOutOfRange,
+      updateInternalDependents,
       useCalculatedVersionForSnapshots
     } = json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH;
     if (
@@ -263,6 +252,18 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
           null,
           2
         )} when the only valid values are undefined or a boolean`
+      );
+    }
+    if (
+      updateInternalDependents !== undefined &&
+      !["always", "out-of-range"].includes(updateInternalDependents)
+    ) {
+      messages.push(
+        `The \`updateInternalDependents\` option is set as ${JSON.stringify(
+          updateInternalDependents,
+          null,
+          2
+        )} but can only be 'always' or 'out-of-range'`
       );
     }
     if (
@@ -313,10 +314,6 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
         ? defaultWrittenConfig.updateInternalDependencies
         : json.updateInternalDependencies,
 
-    updateInternalDependents:
-      json.updateInternalDependents ??
-      defaultWrittenConfig.updateInternalDependents,
-
     ignore:
       json.ignore === undefined
         ? defaultWrittenConfig.ignore
@@ -333,6 +330,11 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
           ? false
           : json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
               .onlyUpdatePeerDependentsWhenOutOfRange,
+
+      updateInternalDependents:
+        json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
+          ?.updateInternalDependents ??
+        defaultWrittenConfig.updateInternalDependents,
 
       useCalculatedVersionForSnapshots:
         json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH === undefined ||

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -16,7 +16,7 @@ export let defaultWrittenConfig = {
   access: "restricted",
   baseBranch: "master",
   updateInternalDependencies: "patch",
-  updateInternalDependents: false,
+  updateInternalDependents: "out-of-range",
   ignore: [] as ReadonlyArray<string>
 } as const;
 
@@ -196,14 +196,14 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
   }
   if (
     json.updateInternalDependents !== undefined &&
-    typeof json.updateInternalDependents !== "boolean"
+    !["always", "out-of-range"].includes(json.updateInternalDependents)
   ) {
     messages.push(
       `The \`updateInternalDependents\` option is set as ${JSON.stringify(
         json.updateInternalDependents,
         null,
         2
-      )} but can only be a boolean`
+      )} but can only be 'always' or 'out-of-range'`
     );
   }
   if (json.ignore) {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -16,6 +16,7 @@ export let defaultWrittenConfig = {
   access: "restricted",
   baseBranch: "master",
   updateInternalDependencies: "patch",
+  updateInternalDependents: false,
   ignore: [] as ReadonlyArray<string>
 } as const;
 
@@ -193,6 +194,18 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
       )} but can only be 'patch' or 'minor'`
     );
   }
+  if (
+    json.updateInternalDependents !== undefined &&
+    typeof json.updateInternalDependents !== "boolean"
+  ) {
+    messages.push(
+      `The \`updateInternalDependents\` option is set as ${JSON.stringify(
+        json.updateInternalDependents,
+        null,
+        2
+      )} but can only be a boolean`
+    );
+  }
   if (json.ignore) {
     if (
       !(
@@ -299,6 +312,10 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
       json.updateInternalDependencies === undefined
         ? defaultWrittenConfig.updateInternalDependencies
         : json.updateInternalDependencies,
+
+    updateInternalDependents:
+      json.updateInternalDependents ??
+      defaultWrittenConfig.updateInternalDependents,
 
     ignore:
       json.ignore === undefined

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -64,7 +64,6 @@ export type Config = {
   baseBranch: string;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies: "patch" | "minor";
-  updateInternalDependents: "always" | "out-of-range";
   ignore: ReadonlyArray<string>;
   bumpVersionsWithWorkspaceProtocolOnly?: boolean;
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: Required<
@@ -80,7 +79,6 @@ export type WrittenConfig = {
   baseBranch?: string;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies?: "patch" | "minor";
-  updateInternalDependents?: "always" | "out-of-range";
   ignore?: ReadonlyArray<string>;
   bumpVersionsWithWorkspaceProtocolOnly?: boolean;
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH?: ExperimentalOptions;
@@ -88,6 +86,7 @@ export type WrittenConfig = {
 
 export type ExperimentalOptions = {
   onlyUpdatePeerDependentsWhenOutOfRange?: boolean;
+  updateInternalDependents?: "always" | "out-of-range";
   useCalculatedVersionForSnapshots?: boolean;
 };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -64,7 +64,7 @@ export type Config = {
   baseBranch: string;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies: "patch" | "minor";
-  updateInternalDependents: boolean;
+  updateInternalDependents: "always" | "out-of-range";
   ignore: ReadonlyArray<string>;
   bumpVersionsWithWorkspaceProtocolOnly?: boolean;
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: Required<
@@ -80,7 +80,7 @@ export type WrittenConfig = {
   baseBranch?: string;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies?: "patch" | "minor";
-  updateInternalDependents?: boolean;
+  updateInternalDependents?: "always" | "out-of-range";
   ignore?: ReadonlyArray<string>;
   bumpVersionsWithWorkspaceProtocolOnly?: boolean;
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH?: ExperimentalOptions;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -64,6 +64,7 @@ export type Config = {
   baseBranch: string;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies: "patch" | "minor";
+  updateInternalDependents: boolean;
   ignore: ReadonlyArray<string>;
   bumpVersionsWithWorkspaceProtocolOnly?: boolean;
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: Required<
@@ -79,6 +80,7 @@ export type WrittenConfig = {
   baseBranch?: string;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies?: "patch" | "minor";
+  updateInternalDependents?: boolean;
   ignore?: ReadonlyArray<string>;
   bumpVersionsWithWorkspaceProtocolOnly?: boolean;
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH?: ExperimentalOptions;


### PR DESCRIPTION
I'm sorry for some unrelated changes to naming, internal function parameters, etc but they were bugging me or things were slightly harder to read at times to build a proper mental model about the codebase. So I've just adjusted those in the process.

The chosen name for the option can be easily mistaken with already quite confusing `updateInternalDependencies` so I'm very open to changing that - maybe smth like: `bumpInternalDependents`? `upgradeInternalDependents`? `alwaysBumpInternalDependents`? 

In fact - using `updateInternalDependencies` together with `updateInternalDependencies` doesn't make sense. The new option (if used) should always take precedence. So maybe it would be worthwhile to deprecate the `updateInternalDependencies` and group both under smth like `internalBumpingStrategy`?