### PR TITLE
adds a release plan flag to the version command

### DIFF
--- a/.changeset/chilled-birds-smell.md
+++ b/.changeset/chilled-birds-smell.md
@@ -1,0 +1,5 @@
+---
+"@changesets/cli": minor
+---
+
+add a release-plan flag to version command

--- a/packages/cli/src/commands/version/index.ts
+++ b/packages/cli/src/commands/version/index.ts
@@ -23,9 +23,11 @@ export default async function version(
   cwd: string,
   options: {
     snapshot?: string | boolean;
+    releasePlan?: string | boolean;
   },
   config: Config
 ) {
+
   const releaseConfig = {
     ...config,
     // Disable committing when in snapshot mode
@@ -70,6 +72,10 @@ export default async function version(
     preState,
     options.snapshot
   );
+
+  if (options.releasePlan) {
+    return releasePlan;
+  }
 
   await applyReleasePlan(
     releasePlan,

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -13,6 +13,7 @@ import { getPackages } from "@manypkg/get-packages";
 import pre from "../pre";
 import version from "./index";
 import humanId from "human-id";
+import { isExportDeclaration } from "typescript";
 
 const f = fixtures(__dirname);
 
@@ -206,6 +207,14 @@ describe("running version in a simple project", () => {
 
     expect(spy).not.toHaveBeenCalled();
   });
+
+  it("should output a release plan", async () => {
+    await writeChangesets([simpleChangeset2], cwd);
+
+    const releasePlan = await versionCommand(cwd, { ...defaultOptions, releasePlan: true, }, modifiedDefaultConfig);
+    expect(releasePlan.releases.length).toEqual(2)
+  });
+
 
   it("should commit the result if commit config is set", async () => {
     await writeChangesets([simpleChangeset2], cwd);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -42,6 +42,9 @@ const { input, flags } = meow(
         type: "string",
         isMultiple: true
       },
+      releasePlan: {
+        type: "boolean"
+      },
       tag: {
         type: "string"
       }

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -80,8 +80,10 @@ export async function run(
       empty,
       ignore,
       snapshot,
+      releasePlan,
       tag
     }: CliOptions = flags;
+
     const deadFlags = ["updateChangelog", "isPublic", "skipCI", "commit"];
 
     deadFlags.forEach(flag => {
@@ -160,7 +162,12 @@ export async function run(
           throw new ExitError(1);
         }
 
-        await version(cwd, { snapshot }, config);
+        const result = await version(cwd, { snapshot, releasePlan }, config);
+
+        if (releasePlan) {
+          console.log(JSON.stringify(result, null, 2));
+        }
+
         return;
       }
       case "publish": {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -12,6 +12,7 @@ export type CliOptions = {
   since?: string;
   ignore?: string | string[];
   snapshot?: string | boolean;
+  releasePlan?: string | boolean;
   tag?: string;
 };
 


### PR DESCRIPTION
Hey y'all! Long time listener first time caller.

Was thinking it'd be nice to do `changesets version --release-plan` and dump said release plan out to the consumer.

This is a first pass so totally up for any other ideas, additions here, but visibility into the release plan is pretty cool to have. At my last gig (Eventbrite) we dumped the release plan out to a file by manually creating it, and then we could run builds on multiple CI machines using the plan.

Now, I'm at Microsoft and am hoping to leverage changesets here too, and thought I'd go ahead and contribute this idea.

Thanks!