### PR TITLE
Add support for publishConfig.registry

### DIFF
--- a/.changeset/tidy-cherries-stare.md
+++ b/.changeset/tidy-cherries-stare.md
@@ -1,0 +1,6 @@
+---
+"@changesets/cli": patch
+"@changesets/types": patch
+---
+
+Add support for publishConfig.registry

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -51,6 +51,7 @@ export type PackageJSON = {
   publishConfig?: {
     access?: AccessType;
     directory?: string;
+    registry?: string;
   };
 };
 


### PR DESCRIPTION
This field is respected by `npm publish` so we need to use this when querying pkg data from the registry.

Why do we need to provide a parameter in the first place? `npm info` is a "global" command, not a contextual one - after all, we are querying arbitrary pkg data using it. 