### PR TITLE
Remove invalid error handler from git.findCommitAndParent

### DIFF
--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -126,9 +126,7 @@ async function getCommitsThatAddFiles(
       ],
       { cwd }
     );
-    if (logResult.code !== 0) {
-      throw new Error(logResult.stderr.toString());
-    }
+
     const [commitSha, parentSha] = logResult.stdout.toString().split(":");
     return { path: gitPath, commitSha, parentSha };
   }


### PR DESCRIPTION
Hi, this PR resolves the issue with the tests.

Return with non-zero code from `git` command in method `findCommitAndParent` seems to be an accepted behaivior. Not throwing an error there is not an issue.

As an example, in the scenario that we have a shallow clone with 5 commits and the commit that we searching is 10 commits behind, the method `findCommitAndParent` will not find the commit and the parent. In this case the `do-while` loop must do another iteration with a deepen clone.