### PR TITLE
Helpful note about `status` command

### DIFF
--- a/docs/command-line-options.md
+++ b/docs/command-line-options.md
@@ -130,6 +130,8 @@ The status command provides information about the changesets that currently exis
 
 - `--since` - to only display information about changesets since a specific branch or git tag (such as `main`, or the git hash of latest). While this can be used to add a CI check for changesets, we recommend not doing this. We instead recommend using the [changeset bot](https://github.com/apps/changeset-bot) to detect pull requests missing changesets, as not all pull requests need one if you are on github.
 
+> NOTE: `status` will fail if you are in the middle of running `version` or `publish`. If you want to get changeset status at the time of a version increase and publish, you need to run it immediately before running `version`. 
+
 ## pre
 
 ```

--- a/docs/command-line-options.md
+++ b/docs/command-line-options.md
@@ -130,7 +130,7 @@ The status command provides information about the changesets that currently exis
 
 - `--since` - to only display information about changesets since a specific branch or git tag (such as `main`, or the git hash of latest). While this can be used to add a CI check for changesets, we recommend not doing this. We instead recommend using the [changeset bot](https://github.com/apps/changeset-bot) to detect pull requests missing changesets, as not all pull requests need one if you are on github.
 
-> NOTE: `status` will fail if you are in the middle of running `version` or `publish`. If you want to get changeset status at the time of a version increase and publish, you need to run it immediately before running `version`. 
+> NOTE: `status` will fail if you are in the middle of running `version` or `publish`. If you want to get changeset status at the time of a version increase and publish, you need to run it immediately before running `version`.
 
 ## pre
 


### PR DESCRIPTION
I was trying to use the `status` command to generate a JSON output file for using in CI to report back on which version items were being published. I kept trying to get the status after the `version` and `publish` commands as that seemed like the logical state I would be wanting to get status. Hopefully this note helps someone else.