### PR TITLE
Update globby dependency to fix vulnerability

### DIFF
--- a/packages/get-workspaces/package.json
+++ b/packages/get-workspaces/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@changesets/types": "^4.0.1",
     "fs-extra": "^7.0.1",
-    "globby": "^9.2.0",
+    "globby": "^12.0.2",
     "read-yaml-file": "^1.1.0"
   },
   "devDependencies": {}


### PR DESCRIPTION
globby 8.0.0-9.2.0 depends on fast-glob <=2.2.7 which causes a oderate vulnerability. Maybe you wanna update the globby dep?