### PR TITLE
Add resolutions to package.json type definition

### DIFF
--- a/.changeset/hot-weeks-dance.md
+++ b/.changeset/hot-weeks-dance.md
@@ -2,4 +2,4 @@
 "@changesets/types": patch
 ---
 
-Add resolutions to packagejson type definition
+Add `resolutions` to the `PackageJSON` type.

--- a/.changeset/hot-weeks-dance.md
+++ b/.changeset/hot-weeks-dance.md
@@ -1,0 +1,5 @@
+---
+"@changesets/types": patch
+---
+
+Add resolutions to packagejson type definition

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -47,6 +47,7 @@ export type PackageJSON = {
   peerDependencies?: { [key: string]: string };
   devDependencies?: { [key: string]: string };
   optionalDependencies?: { [key: string]: string };
+  resolutions?: { [key: string]: string };
   private?: boolean;
   publishConfig?: {
     access?: AccessType;


### PR DESCRIPTION
Technically workspace packages can have resolutions too, not just root level package.json's.
Ran into this missing when trying to use `@manypkg/get-packages` to clean up workspace resolutions