### PR TITLE
Update README to credit Atlassian before the ownership transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ To make releasing easier, you can use [this changesets github action](https://gi
 # Thanks/Inspiration
 
 - [bolt](https://github.com/boltpkg/bolt) - Brought us a strong concept of how packages in a mono-repo should be able to interconnect, and provided the initial infrastructure to get inter-package information.
-- [atlaskit](https://atlaskit.atlassian.com) - The original home of the changesets code, and where many of the ideas and processes were fermented.
+- [Atlassian](https://www.atlassian.com/) - The original idea/sponsor of the changesets code, and where many of the ideas and processes were fermented. It was originally implemented by the team behind [atlaskit](https://atlaskit.atlassian.com).
 - [lerna-semantic-release](https://github.com/atlassian/lerna-semantic-release) - put down many of the initial patterns around updating packages within a multi-package-repository, and started us thinking about how to manage dependent packages.
 - [Thinkmill](https://www.thinkmill.com.au) - For sponsoring the focused open sourcing of this project, and the version two rearchitecture.


### PR DESCRIPTION
Update the credit part of the README before the ownership transfer.

Clearly state the company name Atlassian instead of just the product (or a subset of the products) Atlaskit. 
